### PR TITLE
feat(examples): add examples submodule with Neptune and labeler workflows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples"]
+	path = examples
+	url = https://github.com/devopsfactory-io/neptune-infra-examples.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Guidance for AI coding agents working on the Neptune project.
 - **`internal/github`** – GitHub API client, PR requirements (approved, mergeable, undiverged), commit statuses (GetHeadSHA, CreateCommitStatus) for **neptune plan** / **neptune apply**; GraphQL EnablePullRequestAutoMerge when `repository.automerge` is true.
 - **`internal/git`** – Rebased check; DefaultBranch (git CLI), ShowFileFromRef, FetchBranch for loading config from default branch.
 - **`internal/notifications/github`** – Format and post PR comments.
+- **`examples/`** – Infra examples submodule ([neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples)): S3/GCS backend, automerge, Terramate stacks, Terragrunt. Run `git submodule update --init --recursive` to fetch.
 - **`e2e/`** – End-to-end tests: three Terramate stacks (null_resource/local_file), MinIO via Docker Compose, and `run.sh` that runs Neptune plan/apply with `NEPTUNE_E2E=1` (skips GitHub; see [e2e/README.md](e2e/README.md)).
 - **`lambda/`** – AWS Lambda handler for Neptune GitHub App webhooks (verify signature, parse `pull_request`—including `labeled` when the added label is `NEPTUNE_PR_LABEL`—and `issue_comment`, trigger `repository_dispatch`; optional `NEPTUNE_PR_LABEL` gates on PR label). See [lambda/README.md](lambda/README.md).
 - **`lambda/cloudformation/`** – CloudFormation template to deploy the Lambda (Function URL, IAM, Secrets Manager). See [lambda/README.md](lambda/README.md#deploy-with-cloudformation).
@@ -75,7 +76,7 @@ Use Go version from `go.mod`. No other prerequisites for building or testing the
 - **Coverage**: Existing tests cover `internal/config`, `internal/git`, `internal/github`, `internal/run`, `internal/notifications/github`; add tests for new behavior and keep coverage for touched code.
 - **No external services**: Unit tests should not require live GitHub or GCS; mock or stub as needed.
 - **E2E**: Run `make e2e` or `./e2e/run.sh` (requires Docker, Terraform). Uses MinIO and `NEPTUNE_E2E=1` to skip GitHub. E2E config uses steps with default `terramate: true` (Neptune runs commands per stack via SDK; Terramate CLI not required for steps).
-- **Automerge**: E2E and integration tests in this repo do not exercise the automerge feature. A separate repository (e.g. devopsfactory-io/neptune-infra-example) can be used to test automerge end-to-end (e.g. open a PR with changes in two stacks, comment `@neptbot apply`, then verify the apply comment and that the PR is set to auto-merge after checks pass).
+- **Automerge**: E2E and integration tests in this repo do not exercise the automerge feature. A separate repository (e.g. [devopsfactory-io/neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples)) can be used to test automerge end-to-end (e.g. open a PR with changes in two stacks, comment `@neptbot apply`, then verify the apply comment and that the PR is set to auto-merge after checks pass). That repo is available in-repo at [examples/](examples/) when the submodule is initialized (`git submodule update --init --recursive`).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing. We welcome contributions and encour
 
 ## Getting started
 
-1. Fork the repository and clone your fork.
+1. Fork the repository and clone your fork (use `git clone --recurse-submodules` to include infra examples, or run `git submodule update --init --recursive` after a normal clone).
 2. Create a branch from `main` for your changes.
 3. Set up your environment and run the project locally. See [docs/development.md](docs/development.md) for build and test commands (e.g. `make build`, `make test-all`, `make check-fmt`). Use the Go version from [go.mod](go.mod).
 
@@ -28,6 +28,7 @@ Thank you for your interest in contributing. We welcome contributions and encour
 
 - **Code style**: Format with `gofmt -s` and run `make check-fmt` before committing. Linting follows [.golangci.yml](.golangci.yml). For more detail, see [AGENTS.md](AGENTS.md).
 - **Documentation**: When you change behavior, configuration, or setup, update the relevant docs: [README.md](README.md), [docs/](docs/), and/or [AGENTS.md](AGENTS.md) as appropriate. See the project's documentation guidelines (e.g. in [.cursor/rules](.cursor/rules) or [.cursor/skills/maintain-documentation](.cursor/skills/maintain-documentation/)).
+- **Infra examples**: Live in the `examples` submodule ([neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples)); run `git submodule update --init --recursive` to fetch them.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **Documentation**: [docs/](docs/README.md) – Configuration, object storage, installation, usage, and development. Log level can be set via `log_level` in config or `NEPTUNE_LOG_LEVEL` (DEBUG, INFO, ERROR).
 - **E2E tests**: [e2e/README.md](e2e/README.md) – Run against MinIO with `./e2e/run.sh` or `make e2e`
 - **Releases**: [github.com/devopsfactory-io/neptune/releases](https://github.com/devopsfactory-io/neptune/releases)
+- **Infra examples**: [examples/](examples/) – S3/GCS backend, automerge, Terramate stacks, Terragrunt (from [neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples); Git submodule — run `git submodule update --init --recursive` after clone to fetch).
 - **neptbot**: Trigger Neptune from PR open and @-mention comments by [installing the neptbot GitHub App](docs/github-app-and-lambda.md) and adding the workflow (recommended). To self-host, see [lambda/](lambda/) and [lambda/README.md](lambda/README.md).
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md) – how to contribute; [docs/development.md](docs/development.md) and [AGENTS.md](AGENTS.md) for setup and AI/contributor guidance
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ This folder contains detailed documentation for configuration, object storage, i
 | [Usage](usage.md) | CLI commands (`command plan/apply`, `unlock`) |
 | [GitHub App and Lambda](github-app-and-lambda.md) | Trigger Neptune via GitHub App webhooks and AWS Lambda (`repository_dispatch`) |
 | [Development](development.md) | Building, testing, and contributing |
+| [Examples](../examples/) | Sample configs and backends (S3, GCS, automerge, Terramate, Terragrunt) from the `examples` submodule |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,26 @@
+# neptune-infra-examples
+
+Infrastructure examples for [Neptune](https://github.com/devopsfactory-io/neptune) (Terraform/OpenTofu PR automation with Terramate).
+
+This repository is intended to be used as the **examples** submodule of the Neptune repo; from Neptune root run `git submodule update --init --recursive` to fetch it.
+
+These examples show different ways to use [Neptune](https://github.com/devopsfactory-io/neptune) for Terraform/OpenTofu pull request automation: object storage backends (S3, GCS), PR automerge, Terramate stacks with Terraform, and Terragrunt with Terramate.
+
+| Example | Description |
+|---------|-------------|
+| [s3-backend](s3-backend/) | Neptune with **S3** (or MinIO) for stack lock storage |
+| [gcs-backend](gcs-backend/) | Neptune with **GCS** for stack lock storage |
+| [automerge](automerge/) | **PR automerge** after successful apply (`repository.automerge: true`) |
+| [terramate-stacks](terramate-stacks/) | **Terramate stacks** with plain Terraform; Neptune runs steps per changed stack |
+| [terragrunt-terramate](terragrunt-terramate/) | **Terragrunt** with Terramate stacks; Neptune runs Terragrunt per stack |
+
+Each example is self-contained: Terramate root, stacks, `.neptune.yaml`, and a README with required environment variables and usage.
+
+## Neptune config in CI
+
+Neptune loads `.neptune.yaml` from the **default branch** of your repository in CI (so PR authors cannot change workflow steps). See [Neptune documentation](https://github.com/devopsfactory-io/neptune/tree/main/docs) for [configuration](https://github.com/devopsfactory-io/neptune/blob/main/docs/configuration.md) and [object storage](https://github.com/devopsfactory-io/neptune/blob/main/docs/object-storage.md).
+
+## Using these examples
+
+- **As a submodule from Neptune**: From the Neptune repo root, run `git submodule update --init --recursive` to fetch this repo into `examples/`. The examples listed above then live under `examples/examples/`.
+- **Standalone**: Clone [neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples) and copy or adapt the example you need; set the required env vars and replace placeholder bucket names in `.neptune.yaml`.

--- a/examples/automerge/.github/labeler.yml
+++ b/examples/automerge/.github/labeler.yml
@@ -1,0 +1,3 @@
+neptune:
+  - changed-files:
+    - any-glob-to-any-file: '**'

--- a/examples/automerge/.github/workflows/labeler.yml
+++ b/examples/automerge/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Execute Labeler"
+        uses: actions/labeler@v5

--- a/examples/automerge/.github/workflows/neptune.yml
+++ b/examples/automerge/.github/workflows/neptune.yml
@@ -1,0 +1,47 @@
+# Triggered by the Neptune GitHub App (neptbot or self-hosted) via repository_dispatch.
+# With repository.automerge: true, Neptune enables PR auto-merge after successful apply (token needs pull_requests: write).
+name: neptune
+
+on:
+  repository_dispatch:
+    types: [neptune-command]
+
+concurrency:
+  group: neptune-${{ github.event.client_payload.pull_request_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  neptune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.client_payload.pull_request_number }}/head
+
+      - name: Install Neptune
+        run: |
+          NEPTUNE_VERSION="v0.2.0"
+          curl -sSL "https://github.com/devopsfactory-io/neptune/releases/download/${NEPTUNE_VERSION}/neptune_${NEPTUNE_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin neptune
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+
+      - name: Run Neptune
+        run: neptune command ${{ github.event.client_payload.command }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request_number }}
+          GITHUB_PULL_REQUEST_BRANCH: ${{ github.event.client_payload.pull_request_branch }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/examples/automerge/.neptune.yaml
+++ b/examples/automerge/.neptune.yaml
@@ -1,0 +1,23 @@
+repository:
+  object_storage: s3://your-bucket
+  branch: main
+  plan_requirements:
+    - undiverged
+  apply_requirements:
+    - approved
+    - mergeable
+    - undiverged
+  allowed_workflow: default
+  automerge: true
+
+workflows:
+  default:
+    plan:
+      steps:
+        - run: terraform init -input=false
+        - run: terraform plan -input=false -out=tfplan
+    apply:
+      depends_on:
+        - plan
+      steps:
+        - run: terraform apply -input=false tfplan

--- a/examples/automerge/README.md
+++ b/examples/automerge/README.md
@@ -1,0 +1,14 @@
+# Automerge example
+
+After a successful **apply**, Neptune can enable GitHub **auto-merge** on the pull request so it merges when all required checks pass. This example sets `repository.automerge: true` in `.neptune.yaml`.
+
+## Requirements
+
+- The GitHub token used by Neptune must have permission to enable auto-merge on pull requests. In GitHub Actions, grant `pull_requests: write` to the job that runs Neptune.
+- Auto-merge is only triggered after a successful **apply**, not after plan.
+
+See [Neptune configuration](https://github.com/devopsfactory-io/neptune/blob/main/docs/configuration.md) for the `automerge` option and repository fields.
+
+## Setup
+
+Replace `s3://your-bucket` (or use `gs://your-bucket`) and set the same object-storage environment variables as in the [s3-backend](s3-backend/) or [gcs-backend](gcs-backend/) examples.

--- a/examples/automerge/stack-a/main.tf
+++ b/examples/automerge/stack-a/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_a" {
+  triggers = {
+    stack = "stack-a"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-a output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/automerge/stack-a/stack.tm.hcl
+++ b/examples/automerge/stack-a/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-a"
+  description = "Automerge example stack A"
+}

--- a/examples/automerge/stack-b/main.tf
+++ b/examples/automerge/stack-b/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_b" {
+  triggers = {
+    stack = "stack-b"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-b output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/automerge/stack-b/stack.tm.hcl
+++ b/examples/automerge/stack-b/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-b"
+  description = "Automerge example stack B"
+}

--- a/examples/automerge/terramate.tm.hcl
+++ b/examples/automerge/terramate.tm.hcl
@@ -1,0 +1,7 @@
+# Root Terramate config for automerge example.
+terramate {
+  required_version = ">= 0.1.0"
+  config {
+    disable_safeguards = ["git-untracked", "git-uncommitted"]
+  }
+}

--- a/examples/gcs-backend/.github/labeler.yml
+++ b/examples/gcs-backend/.github/labeler.yml
@@ -1,0 +1,3 @@
+neptune:
+  - changed-files:
+    - any-glob-to-any-file: '**'

--- a/examples/gcs-backend/.github/workflows/labeler.yml
+++ b/examples/gcs-backend/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Execute Labeler"
+        uses: actions/labeler@v5

--- a/examples/gcs-backend/.github/workflows/neptune.yml
+++ b/examples/gcs-backend/.github/workflows/neptune.yml
@@ -1,0 +1,49 @@
+# Triggered by the Neptune GitHub App (neptbot or self-hosted) via repository_dispatch.
+# Install the app on this repo and add GCS credentials (e.g. GCP_SA_KEY secret) per this example's README.
+name: neptune
+
+on:
+  repository_dispatch:
+    types: [neptune-command]
+
+concurrency:
+  group: neptune-${{ github.event.client_payload.pull_request_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  neptune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.client_payload.pull_request_number }}/head
+
+      - name: Install Neptune
+        run: |
+          NEPTUNE_VERSION="v0.2.0"
+          curl -sSL "https://github.com/devopsfactory-io/neptune/releases/download/${NEPTUNE_VERSION}/neptune_${NEPTUNE_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin neptune
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+
+      - name: Authenticate to Google Cloud
+        run: |
+          echo '${{ secrets.GCP_SA_KEY }}' > "${{ github.workspace }}/gcp-key.json"
+
+      - name: Run Neptune
+        run: neptune command ${{ github.event.client_payload.command }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request_number }}
+          GITHUB_PULL_REQUEST_BRANCH: ${{ github.event.client_payload.pull_request_branch }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/gcp-key.json

--- a/examples/gcs-backend/.neptune.yaml
+++ b/examples/gcs-backend/.neptune.yaml
@@ -1,0 +1,22 @@
+repository:
+  object_storage: gs://your-bucket
+  branch: main
+  plan_requirements:
+    - undiverged
+  apply_requirements:
+    - approved
+    - mergeable
+    - undiverged
+  allowed_workflow: default
+
+workflows:
+  default:
+    plan:
+      steps:
+        - run: terraform init -input=false
+        - run: terraform plan -input=false -out=tfplan
+    apply:
+      depends_on:
+        - plan
+      steps:
+        - run: terraform apply -input=false tfplan

--- a/examples/gcs-backend/README.md
+++ b/examples/gcs-backend/README.md
@@ -1,0 +1,12 @@
+# GCS backend example
+
+Neptune stores stack lock files in **Google Cloud Storage (GCS)**. This example uses `object_storage: gs://your-bucket` in `.neptune.yaml`.
+
+## Setup
+
+1. Replace `gs://your-bucket` in `.neptune.yaml` with your bucket (and optional prefix), e.g. `gs://my-neptune-locks` or `gs://my-bucket/neptune/prefix`.
+2. Set credentials for the Google Cloud client (see [Neptune object storage docs](https://github.com/devopsfactory-io/neptune/blob/main/docs/object-storage.md)):
+   - **Service account key**: Set `GOOGLE_APPLICATION_CREDENTIALS` to the path of your service account JSON key file.
+   - **Application Default Credentials**: Alternatively use [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) (e.g. `gcloud auth application-default login`).
+
+No GCP resources are created by the Terraform in this example (only `null_resource` and `local_file`); Neptune uses GCS only for lock files.

--- a/examples/gcs-backend/stack-a/main.tf
+++ b/examples/gcs-backend/stack-a/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_a" {
+  triggers = {
+    stack = "stack-a"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-a output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/gcs-backend/stack-a/stack.tm.hcl
+++ b/examples/gcs-backend/stack-a/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-a"
+  description = "GCS backend example stack A"
+}

--- a/examples/gcs-backend/stack-b/main.tf
+++ b/examples/gcs-backend/stack-b/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_b" {
+  triggers = {
+    stack = "stack-b"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-b output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/gcs-backend/stack-b/stack.tm.hcl
+++ b/examples/gcs-backend/stack-b/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-b"
+  description = "GCS backend example stack B"
+}

--- a/examples/gcs-backend/terramate.tm.hcl
+++ b/examples/gcs-backend/terramate.tm.hcl
@@ -1,0 +1,7 @@
+# Root Terramate config for GCS-backend example.
+terramate {
+  required_version = ">= 0.1.0"
+  config {
+    disable_safeguards = ["git-untracked", "git-uncommitted"]
+  }
+}

--- a/examples/s3-backend/.github/labeler.yml
+++ b/examples/s3-backend/.github/labeler.yml
@@ -1,0 +1,3 @@
+neptune:
+  - changed-files:
+    - any-glob-to-any-file: '**'

--- a/examples/s3-backend/.github/workflows/labeler.yml
+++ b/examples/s3-backend/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Execute Labeler"
+        uses: actions/labeler@v5

--- a/examples/s3-backend/.github/workflows/neptune.yml
+++ b/examples/s3-backend/.github/workflows/neptune.yml
@@ -1,0 +1,47 @@
+# Triggered by the Neptune GitHub App (neptbot or self-hosted) via repository_dispatch.
+# Install the app on this repo and add object-storage secrets (e.g. AWS_* for S3) per this example's README.
+name: neptune
+
+on:
+  repository_dispatch:
+    types: [neptune-command]
+
+concurrency:
+  group: neptune-${{ github.event.client_payload.pull_request_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  neptune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.client_payload.pull_request_number }}/head
+
+      - name: Install Neptune
+        run: |
+          NEPTUNE_VERSION="v0.2.0"
+          curl -sSL "https://github.com/devopsfactory-io/neptune/releases/download/${NEPTUNE_VERSION}/neptune_${NEPTUNE_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin neptune
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+
+      - name: Run Neptune
+        run: neptune command ${{ github.event.client_payload.command }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request_number }}
+          GITHUB_PULL_REQUEST_BRANCH: ${{ github.event.client_payload.pull_request_branch }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/examples/s3-backend/.neptune.yaml
+++ b/examples/s3-backend/.neptune.yaml
@@ -1,0 +1,22 @@
+repository:
+  object_storage: s3://your-bucket
+  branch: main
+  plan_requirements:
+    - undiverged
+  apply_requirements:
+    - approved
+    - mergeable
+    - undiverged
+  allowed_workflow: default
+
+workflows:
+  default:
+    plan:
+      steps:
+        - run: terraform init -input=false
+        - run: terraform plan -input=false -out=tfplan
+    apply:
+      depends_on:
+        - plan
+      steps:
+        - run: terraform apply -input=false tfplan

--- a/examples/s3-backend/README.md
+++ b/examples/s3-backend/README.md
@@ -1,0 +1,12 @@
+# S3 backend example
+
+Neptune stores stack lock files in **AWS S3** (or S3-compatible storage such as MinIO). This example uses `object_storage: s3://your-bucket` in `.neptune.yaml`.
+
+## Setup
+
+1. Replace `s3://your-bucket` in `.neptune.yaml` with your bucket (and optional prefix), e.g. `s3://my-neptune-locks` or `s3://my-bucket/neptune/prefix`.
+2. Set environment variables for the AWS SDK (see [Neptune object storage docs](https://github.com/devopsfactory-io/neptune/blob/main/docs/object-storage.md)):
+   - **AWS S3**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` (e.g. `us-east-1`). Alternatively use IAM roles (e.g. GitHub Actions OIDC) with no env vars.
+   - **MinIO (S3-compatible)**: Same as above, plus `AWS_ENDPOINT_URL_S3` (or `AWS_ENDPOINT_URL`) pointing to your MinIO URL, e.g. `http://minio.example.com:9000`. Set `AWS_REGION` if your MinIO setup requires it.
+
+No AWS resources are created by the Terraform in this example (only `null_resource` and `local_file`); Neptune uses S3 only for lock files.

--- a/examples/s3-backend/stack-a/main.tf
+++ b/examples/s3-backend/stack-a/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_a" {
+  triggers = {
+    stack = "stack-a"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-a output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/s3-backend/stack-a/stack.tm.hcl
+++ b/examples/s3-backend/stack-a/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-a"
+  description = "S3 backend example stack A"
+}

--- a/examples/s3-backend/stack-b/main.tf
+++ b/examples/s3-backend/stack-b/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_b" {
+  triggers = {
+    stack = "stack-b"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-b output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/s3-backend/stack-b/stack.tm.hcl
+++ b/examples/s3-backend/stack-b/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-b"
+  description = "S3 backend example stack B"
+}

--- a/examples/s3-backend/terramate.tm.hcl
+++ b/examples/s3-backend/terramate.tm.hcl
@@ -1,0 +1,8 @@
+# Root Terramate config for S3-backend example.
+# required_version is required for Terramate to detect this as the root config.
+terramate {
+  required_version = ">= 0.1.0"
+  config {
+    disable_safeguards = ["git-untracked", "git-uncommitted"]
+  }
+}

--- a/examples/terragrunt-terramate/.github/labeler.yml
+++ b/examples/terragrunt-terramate/.github/labeler.yml
@@ -1,0 +1,3 @@
+neptune:
+  - changed-files:
+    - any-glob-to-any-file: '**'

--- a/examples/terragrunt-terramate/.github/workflows/labeler.yml
+++ b/examples/terragrunt-terramate/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Execute Labeler"
+        uses: actions/labeler@v5

--- a/examples/terragrunt-terramate/.github/workflows/neptune.yml
+++ b/examples/terragrunt-terramate/.github/workflows/neptune.yml
@@ -1,0 +1,53 @@
+# Triggered by the Neptune GitHub App (neptbot or self-hosted) via repository_dispatch.
+# This example runs Terragrunt; Terragrunt is installed in the workflow.
+name: neptune
+
+on:
+  repository_dispatch:
+    types: [neptune-command]
+
+concurrency:
+  group: neptune-${{ github.event.client_payload.pull_request_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  neptune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.client_payload.pull_request_number }}/head
+
+      - name: Install Neptune
+        run: |
+          NEPTUNE_VERSION="v0.2.0"
+          curl -sSL "https://github.com/devopsfactory-io/neptune/releases/download/${NEPTUNE_VERSION}/neptune_${NEPTUNE_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin neptune
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+
+      - name: Install Terragrunt
+        run: |
+          TERRAGRUNT_VERSION="0.54.0"
+          curl -sSL "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64" -o /usr/local/bin/terragrunt
+          chmod +x /usr/local/bin/terragrunt
+
+      - name: Run Neptune
+        run: neptune command ${{ github.event.client_payload.command }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request_number }}
+          GITHUB_PULL_REQUEST_BRANCH: ${{ github.event.client_payload.pull_request_branch }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/examples/terragrunt-terramate/.neptune.yaml
+++ b/examples/terragrunt-terramate/.neptune.yaml
@@ -1,0 +1,22 @@
+repository:
+  object_storage: s3://your-bucket
+  branch: main
+  plan_requirements:
+    - undiverged
+  apply_requirements:
+    - approved
+    - mergeable
+    - undiverged
+  allowed_workflow: default
+
+workflows:
+  default:
+    plan:
+      steps:
+        - run: terragrunt init -upgrade
+        - run: terragrunt plan
+    apply:
+      depends_on:
+        - plan
+      steps:
+        - run: terragrunt apply -auto-approve

--- a/examples/terragrunt-terramate/README.md
+++ b/examples/terragrunt-terramate/README.md
@@ -1,0 +1,8 @@
+# Terragrunt with Terramate stacks example
+
+This example uses **Terragrunt** with **Terramate** stacks. Neptune runs each workflow step (e.g. `terragrunt init`, `terragrunt plan`, `terragrunt apply`) **once per changed stack**, with the working directory set to that stack. No Terramate CLI is required for that: Neptune uses the Terramate SDK to list changed stacks and run in order.
+
+- **Layout**: Each stack (`stack-a/`, `stack-b/`) has a `terragrunt.hcl` that sources a shared module (`_modules/minimal`). The Terraform backend in the module is `local` so no cloud state backend is required for this example.
+- **Alternative**: You can set `terramate: false` on a step and run `terramate run --changed -- terragrunt plan` (and similar for apply); in that case the Terramate CLI must be installed, and Neptune runs the command once at repo root.
+
+Replace `s3://your-bucket` in `.neptune.yaml` and set object-storage env vars as in the [s3-backend](s3-backend/) example. Ensure Terragrunt is installed in the environment where Neptune runs (e.g. CI).

--- a/examples/terragrunt-terramate/_modules/minimal/main.tf
+++ b/examples/terragrunt-terramate/_modules/minimal/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+variable "stack_name" {
+  type = string
+}
+
+resource "null_resource" "stack" {
+  triggers = {
+    stack = var.stack_name
+  }
+}
+
+resource "local_file" "out" {
+  content  = "${var.stack_name} output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/terragrunt-terramate/stack-a/stack.tm.hcl
+++ b/examples/terragrunt-terramate/stack-a/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-a"
+  description = "Terragrunt + Terramate example stack A"
+}

--- a/examples/terragrunt-terramate/stack-a/terragrunt.hcl
+++ b/examples/terragrunt-terramate/stack-a/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../_modules/minimal"
+}
+
+inputs = {
+  stack_name = "stack-a"
+}

--- a/examples/terragrunt-terramate/stack-b/stack.tm.hcl
+++ b/examples/terragrunt-terramate/stack-b/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-b"
+  description = "Terragrunt + Terramate example stack B"
+}

--- a/examples/terragrunt-terramate/stack-b/terragrunt.hcl
+++ b/examples/terragrunt-terramate/stack-b/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../_modules/minimal"
+}
+
+inputs = {
+  stack_name = "stack-b"
+}

--- a/examples/terragrunt-terramate/terramate.tm.hcl
+++ b/examples/terragrunt-terramate/terramate.tm.hcl
@@ -1,0 +1,7 @@
+# Root Terramate config for Terragrunt + Terramate example.
+terramate {
+  required_version = ">= 0.1.0"
+  config {
+    disable_safeguards = ["git-untracked", "git-uncommitted"]
+  }
+}

--- a/examples/terramate-stacks/.github/labeler.yml
+++ b/examples/terramate-stacks/.github/labeler.yml
@@ -1,0 +1,3 @@
+neptune:
+  - changed-files:
+    - any-glob-to-any-file: '**'

--- a/examples/terramate-stacks/.github/workflows/labeler.yml
+++ b/examples/terramate-stacks/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Execute Labeler"
+        uses: actions/labeler@v5

--- a/examples/terramate-stacks/.github/workflows/neptune.yml
+++ b/examples/terramate-stacks/.github/workflows/neptune.yml
@@ -1,0 +1,46 @@
+# Triggered by the Neptune GitHub App (neptbot or self-hosted) via repository_dispatch.
+name: neptune
+
+on:
+  repository_dispatch:
+    types: [neptune-command]
+
+concurrency:
+  group: neptune-${{ github.event.client_payload.pull_request_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  neptune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.client_payload.pull_request_number }}/head
+
+      - name: Install Neptune
+        run: |
+          NEPTUNE_VERSION="v0.2.0"
+          curl -sSL "https://github.com/devopsfactory-io/neptune/releases/download/${NEPTUNE_VERSION}/neptune_${NEPTUNE_VERSION}_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin neptune
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+
+      - name: Run Neptune
+        run: neptune command ${{ github.event.client_payload.command }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request_number }}
+          GITHUB_PULL_REQUEST_BRANCH: ${{ github.event.client_payload.pull_request_branch }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/examples/terramate-stacks/.neptune.yaml
+++ b/examples/terramate-stacks/.neptune.yaml
@@ -1,0 +1,23 @@
+repository:
+  object_storage: s3://your-bucket
+  branch: main
+  plan_requirements:
+    - undiverged
+  apply_requirements:
+    - approved
+    - mergeable
+    - undiverged
+  allowed_workflow: default
+
+workflows:
+  default:
+    plan:
+      steps:
+        # terramate: true (default) = Neptune runs each step once per changed stack in that stack's dir
+        - run: terraform init -input=false
+        - run: terraform plan -input=false -out=tfplan
+    apply:
+      depends_on:
+        - plan
+      steps:
+        - run: terraform apply -input=false tfplan

--- a/examples/terramate-stacks/README.md
+++ b/examples/terramate-stacks/README.md
@@ -1,0 +1,10 @@
+# Terramate stacks example
+
+This example shows **Terramate stacks** with plain Terraform. Neptune runs each workflow step **once per changed stack**, with the working directory set to that stack. The Terramate CLI is **not** required for this: Neptune uses the Terramate Go SDK for change detection and run order.
+
+- **terramate: true** (default): Neptune executes the step’s `run` command in each changed stack directory.
+- **terramate: false**: Run the command once (e.g. at repo root); use this if you invoke the Terramate CLI yourself, e.g. `run: terramate run --changed -- some-command`.
+
+See [Neptune configuration – Step options: terramate and changed](https://github.com/devopsfactory-io/neptune/blob/main/docs/configuration.md) for details.
+
+Replace `s3://your-bucket` in `.neptune.yaml` and set object-storage env vars as in the [s3-backend](s3-backend/) example.

--- a/examples/terramate-stacks/stack-a/main.tf
+++ b/examples/terramate-stacks/stack-a/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_a" {
+  triggers = {
+    stack = "stack-a"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-a output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/terramate-stacks/stack-a/stack.tm.hcl
+++ b/examples/terramate-stacks/stack-a/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-a"
+  description = "Terramate stacks example stack A"
+}

--- a/examples/terramate-stacks/stack-b/main.tf
+++ b/examples/terramate-stacks/stack-b/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "null_resource" "stack_b" {
+  triggers = {
+    stack = "stack-b"
+  }
+}
+
+resource "local_file" "out" {
+  content  = "stack-b output"
+  filename = "${path.module}/out.txt"
+}

--- a/examples/terramate-stacks/stack-b/stack.tm.hcl
+++ b/examples/terramate-stacks/stack-b/stack.tm.hcl
@@ -1,0 +1,4 @@
+stack {
+  name        = "stack-b"
+  description = "Terramate stacks example stack B"
+}

--- a/examples/terramate-stacks/terramate.tm.hcl
+++ b/examples/terramate-stacks/terramate.tm.hcl
@@ -1,0 +1,7 @@
+# Root Terramate config for Terramate-stacks example.
+terramate {
+  required_version = ">= 0.1.0"
+  config {
+    disable_safeguards = ["git-untracked", "git-uncommitted"]
+  }
+}


### PR DESCRIPTION
## What is this feature?

Add the **neptune-infra-examples** repository as the `examples` submodule and populate it with five self-contained examples (S3 backend, GCS backend, automerge, Terramate stacks, Terragrunt with Terramate). Each example includes a `.github` folder with the Neptune workflow (triggered via `repository_dispatch`) and the labeler workflow so examples are complete and copy-paste ready.

## Why do we need this feature?

Users need reference examples that show how to configure Neptune (object storage, automerge, Terramate, Terragrunt) and that include the required GitHub workflows (neptune + labeler) so they can clone or copy an example and run it with minimal setup.

## Who is this feature for?

Teams adopting Neptune who want to see working configs and CI workflows for different backends and patterns (S3, GCS, automerge, Terramate, Terragrunt).

## Related issues

<!-- None -->

## Notes for reviewers

- Examples live under `examples/` (submodule path). Each example has `.neptune.yaml`, Terramate stacks, and `.github/workflows/neptune.yml` + `.github/workflows/labeler.yml` + `.github/labeler.yml`.
- GCS example workflow writes `GCP_SA_KEY` secret to a file for `GOOGLE_APPLICATION_CREDENTIALS`; terragrunt-terramate installs Terragrunt in the workflow.
- Docs (README, AGENTS.md, CONTRIBUTING.md, docs/README.md) were updated to link to the examples and document submodule clone instructions.

---

## Checklist

- [x] **Breaking changes?** No
- [x] **Documentation updated** (README, docs/, AGENTS.md, CONTRIBUTING.md)
- [x] **Tests added or updated** N/A (docs and example content; no code changes in main module)

---

## AI Summary

- **Scope:** examples submodule, .gitmodules, README, docs/README.md, AGENTS.md, CONTRIBUTING.md; each example: .neptune.yaml, terramate.tm.hcl, stacks, .github/workflows (neptune.yml, labeler.yml), .github/labeler.yml
- **Type:** feat
- **Key files/areas:** .gitmodules, examples/* (s3-backend, gcs-backend, automerge, terramate-stacks, terragrunt-terramate), README.md, docs/README.md, AGENTS.md, CONTRIBUTING.md
