### PR TITLE
docs: remove neptune-infra-examples refs and treat examples as documentation

### DIFF
--- a/.cursor/rules/config-and-yaml.mdc
+++ b/.cursor/rules/config-and-yaml.mdc
@@ -9,4 +9,4 @@ alwaysApply: false
 - **.neptune.yaml**: Top-level keys are `repository` and `workflows`. `repository` has `object_storage` (must be `gs://...`), `branch`, `plan_requirements`, `apply_requirements`, `allowed_workflow`. `workflows` is a map of workflow name to phases (e.g. `plan`, `apply`) with `steps` (list of `run: "..."`) and optional `depends_on`.
 - **Required env vars**: `NEPTUNE_CONFIG_PATH`, `GITHUB_REPOSITORY`, `GITHUB_PULL_REQUEST_BRANCH`, `GITHUB_PULL_REQUEST_NUMBER`, `GITHUB_RUN_ID`, `GITHUB_TOKEN`.
 - **Validation**: Enforced in `internal/config` (object_storage prefix, allowed requirements, plan+apply phases, terramate+`--changed` for terraform/terragrunt steps).
-- When changing schema or env: update README, `.neptune.example.yaml`, and AGENTS.md or rules so human and AI docs stay in sync.
+- When changing schema or env: update README, `.neptune.example.yaml`, **examples/** (if an example uses the changed config), and AGENTS.md or rules so human and AI docs stay in sync.

--- a/.cursor/rules/docs-and-ai-context.mdc
+++ b/.cursor/rules/docs-and-ai-context.mdc
@@ -7,9 +7,10 @@ alwaysApply: true
 
 After making changes to code, config, or CI:
 
-1. **Ask**: "Do README, AGENTS.md, or any .cursor rule or skill need an update?"
+1. **Ask**: "Do README, AGENTS.md, examples/, or any .cursor rule or skill need an update?"
 2. **New behavior or CLI flags** → Update README and/or AGENTS.md (install, usage, structure).
-3. **New conventions or workflows** → Update the relevant `.cursor/rules/*.mdc` or `.cursor/skills/*/SKILL.md`.
-4. **Do not edit plan files** (e.g. `neptune_go_rewrite*.plan.md`, `ai_agent_config*.plan.md`) unless the user explicitly asks.
+3. **New config or usage that users can try** → Consider adding or updating an example in **examples/** (examples are part of the documentation).
+4. **New conventions or workflows** → Update the relevant `.cursor/rules/*.mdc` or `.cursor/skills/*/SKILL.md`.
+5. **Do not edit plan files** (e.g. `neptune_go_rewrite*.plan.md`, `ai_agent_config*.plan.md`) unless the user explicitly asks.
 
 Use the project skill **maintain-documentation** (`.cursor/skills/maintain-documentation/`) for the full checklist and when to update each artifact.

--- a/.cursor/skills/maintain-documentation/SKILL.md
+++ b/.cursor/skills/maintain-documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintain-documentation
-description: Ensures human and AI documentation stay in sync with code and config. Use when changing behavior, adding features, refactoring, or when the user asks to update docs. Always consider whether README, AGENTS.md, .cursor/rules, or .cursor/skills need updates.
+description: Ensures human and AI documentation stay in sync with code and config. Use when changing behavior, adding features, refactoring, or when the user asks to update docs. Always consider whether README, docs/, examples/, AGENTS.md, .cursor/rules, or .cursor/skills need updates.
 ---
 
 # Maintain Documentation
@@ -18,11 +18,12 @@ Use this skill when:
 
 1. **README.md** – Update if install steps, usage, or config schema changed. Keep high-level content and links to docs accurate.
 2. **docs/*.md** – Update if install, config, object storage, usage, or development steps changed.
-3. **CONTRIBUTING.md** – Update if contributing workflow, issue/PR process, or checklist for contributors changed.
-4. **AGENTS.md** – Update if project structure, setup commands, code style, testing, or CI changed. Keep repo layout and "Documentation and AI context" section accurate.
-5. **.github/** – Update [pull_request_template.md](.github/pull_request_template.md) or [ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) if PR/issue structure or required sections change.
-6. **.cursor/rules/*.mdc** – Update if coding conventions, workflow rules, or file-scoped guidance changed. Match globs to the files the rule applies to.
-7. **.cursor/skills/*/SKILL.md** – Update if a documented workflow (e.g. release steps, test commands, open-pull-request) or checklist changed.
+3. **examples/** – Treat as part of the documentation. Add or update examples when config, workflows, or usage change; keep [examples/README.md](examples/README.md) and per-example READMEs accurate.
+4. **CONTRIBUTING.md** – Update if contributing workflow, issue/PR process, or checklist for contributors changed.
+5. **AGENTS.md** – Update if project structure, setup commands, code style, testing, or CI changed. Keep repo layout and "Documentation and AI context" section accurate.
+6. **.github/** – Update [pull_request_template.md](.github/pull_request_template.md) or [ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) if PR/issue structure or required sections change.
+7. **.cursor/rules/*.mdc** – Update if coding conventions, workflow rules, or file-scoped guidance changed. Match globs to the files the rule applies to.
+8. **.cursor/skills/*/SKILL.md** – Update if a documented workflow (e.g. release steps, test commands, open-pull-request) or checklist changed.
 
 ## Where Things Live
 
@@ -30,6 +31,7 @@ Use this skill when:
 |----------|----------|---------|
 | README.md | Humans | High-level entry point; links to docs and releases |
 | docs/ | Humans | Configuration, object storage, installation, usage, development |
+| examples/ | Humans | Copy-pasteable infra examples (S3/GCS, automerge, Terramate, Terragrunt); part of docs |
 | CONTRIBUTING.md | Humans | How to contribute; issue/PR templates, checklist, CI |
 | .github/pull_request_template.md | Humans + AI | PR description structure; includes AI Summary for reviewers |
 | .github/ISSUE_TEMPLATE/ | Humans | Bug report, feature request, staff issue templates |
@@ -40,8 +42,9 @@ Use this skill when:
 ## When to Update AI Docs
 
 - **New commands or flags** → README and AGENTS.md (structure / usage).
-- **New env vars or config keys** → README, docs/ (configuration.md, object-storage.md), .neptune.example.yaml, config-and-yaml rule.
+- **New env vars or config keys** → README, docs/ (configuration.md, object-storage.md), .neptune.example.yaml, examples/ (if an example should show the new config), config-and-yaml rule.
 - **New Make targets or CI jobs** → AGENTS.md, ci-and-release rule, testing-and-ci skill.
+- **New features or workflow options users can try** → Consider adding or updating an example in **examples/**.
 - **New patterns agents should follow** → Add or update a rule or skill; mention in AGENTS.md if central.
 
 Do not edit plan files (e.g. in .cursor/plans or *.plan.md) unless the user explicitly asks.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "examples"]
-	path = examples
-	url = https://github.com/devopsfactory-io/neptune-infra-examples.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ Guidance for AI coding agents working on the Neptune project.
 - **`internal/github`** – GitHub API client, PR requirements (approved, mergeable, undiverged), commit statuses (GetHeadSHA, CreateCommitStatus) for **neptune plan** / **neptune apply**; GraphQL EnablePullRequestAutoMerge when `repository.automerge` is true.
 - **`internal/git`** – Rebased check; DefaultBranch (git CLI), ShowFileFromRef, FetchBranch for loading config from default branch.
 - **`internal/notifications/github`** – Format and post PR comments.
-- **`examples/`** – Infra examples submodule ([neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples)): S3/GCS backend, automerge, Terramate stacks, Terragrunt. Run `git submodule update --init --recursive` to fetch.
+- **`examples/`** – Infra examples (S3/GCS backend, automerge, Terramate stacks, Terragrunt).
+- **`scripts/`** – Maintainer scripts (if any).
 - **`e2e/`** – End-to-end tests: three Terramate stacks (null_resource/local_file), MinIO via Docker Compose, and `run.sh` that runs Neptune plan/apply with `NEPTUNE_E2E=1` (skips GitHub; see [e2e/README.md](e2e/README.md)).
 - **`lambda/`** – AWS Lambda handler for Neptune GitHub App webhooks (verify signature, parse `pull_request`—including `labeled` when the added label is `NEPTUNE_PR_LABEL`—and `issue_comment`, trigger `repository_dispatch`; optional `NEPTUNE_PR_LABEL` gates on PR label). See [lambda/README.md](lambda/README.md).
 - **`lambda/cloudformation/`** – CloudFormation template to deploy the Lambda (Function URL, IAM, Secrets Manager). See [lambda/README.md](lambda/README.md#deploy-with-cloudformation).
@@ -76,7 +77,7 @@ Use Go version from `go.mod`. No other prerequisites for building or testing the
 - **Coverage**: Existing tests cover `internal/config`, `internal/git`, `internal/github`, `internal/run`, `internal/notifications/github`; add tests for new behavior and keep coverage for touched code.
 - **No external services**: Unit tests should not require live GitHub or GCS; mock or stub as needed.
 - **E2E**: Run `make e2e` or `./e2e/run.sh` (requires Docker, Terraform). Uses MinIO and `NEPTUNE_E2E=1` to skip GitHub. E2E config uses steps with default `terramate: true` (Neptune runs commands per stack via SDK; Terramate CLI not required for steps).
-- **Automerge**: E2E and integration tests in this repo do not exercise the automerge feature. A separate repository (e.g. [devopsfactory-io/neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples)) can be used to test automerge end-to-end (e.g. open a PR with changes in two stacks, comment `@neptbot apply`, then verify the apply comment and that the PR is set to auto-merge after checks pass). That repo is available in-repo at [examples/](examples/) when the submodule is initialized (`git submodule update --init --recursive`).
+- **Automerge**: E2E and integration tests in this repo do not exercise the automerge feature. A separate repository (e.g. a fork or copy of [examples/](examples/)) can be used to test automerge end-to-end (e.g. open a PR with changes in two stacks, comment `@neptbot apply`, then verify the apply comment and that the PR is set to auto-merge after checks pass).
 
 ---
 
@@ -96,10 +97,10 @@ Semantic versioning: use tags like `v0.2.0`. GoReleaser injects version/commit/d
 
 After any change that affects behavior, APIs, config, or CI:
 
-1. **Consider human docs**: **README.md** is the high-level entry point; detailed user docs (configuration, object storage, installation, usage, development) live in **docs/** (see [docs/README.md](docs/README.md)). Update README, **docs/*.md**, and **`.neptune.example.yaml`** (or comments) if install, usage, or config schema changed.
+1. **Consider human docs**: **README.md** is the high-level entry point; detailed user docs (configuration, object storage, installation, usage, development) live in **docs/** (see [docs/README.md](docs/README.md)); **examples/** is part of the documentation (copy-pasteable usage examples). Update README, **docs/*.md**, **examples/** (add or update examples when behavior or config changes), and **`.neptune.example.yaml`** (or comments) if install, usage, or config schema changed.
 2. **Consider AI docs**: Update **AGENTS.md** if project structure, setup, or conventions changed. Update **`.cursor/rules/*.mdc`** if coding or workflow rules changed. Update **`.cursor/skills/*/SKILL.md`** if a documented workflow or checklist changed.
 
-If you add a feature, change a command, or modify workflows: check README, docs/, and AGENTS.md; if rules or skills are affected, update the corresponding file. When in doubt, update. See the project skill **maintain-documentation** (`.cursor/skills/maintain-documentation/`) for a detailed checklist.
+If you add a feature, change a command, or modify workflows: check README, docs/, examples/, and AGENTS.md; if rules or skills are affected, update the corresponding file. When in doubt, update. See the project skill **maintain-documentation** (`.cursor/skills/maintain-documentation/`) for a detailed checklist.
 
 Do not edit plan files (e.g. `neptune_go_rewrite*.plan.md` or `ai_agent_config*.plan.md`) unless the user explicitly asks.
 
@@ -111,7 +112,7 @@ Before submitting:
 
 1. Run `make test-all` and `make check-fmt`.
 2. Ensure no new linter errors (`make lint` if available).
-3. If behavior or setup changed, update README, docs/, and/or AGENTS.md and rules/skills as above.
+3. If behavior or setup changed, update README, docs/, examples/, and/or AGENTS.md and rules/skills as above.
 
 PR titles may follow a conventional style (e.g. `feat(cmd): ...`, `fix(lock): ...`, `docs: ...`) but this is not enforced.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing. We welcome contributions and encour
 
 ## Getting started
 
-1. Fork the repository and clone your fork (use `git clone --recurse-submodules` to include infra examples, or run `git submodule update --init --recursive` after a normal clone).
+1. Fork the repository and clone your fork (infra examples are in the `examples/` directory).
 2. Create a branch from `main` for your changes.
 3. Set up your environment and run the project locally. See [docs/development.md](docs/development.md) for build and test commands (e.g. `make build`, `make test-all`, `make check-fmt`). Use the Go version from [go.mod](go.mod).
 
@@ -28,7 +28,7 @@ Thank you for your interest in contributing. We welcome contributions and encour
 
 - **Code style**: Format with `gofmt -s` and run `make check-fmt` before committing. Linting follows [.golangci.yml](.golangci.yml). For more detail, see [AGENTS.md](AGENTS.md).
 - **Documentation**: When you change behavior, configuration, or setup, update the relevant docs: [README.md](README.md), [docs/](docs/), and/or [AGENTS.md](AGENTS.md) as appropriate. See the project's documentation guidelines (e.g. in [.cursor/rules](.cursor/rules) or [.cursor/skills/maintain-documentation](.cursor/skills/maintain-documentation/)).
-- **Infra examples**: Live in the `examples` submodule ([neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples)); run `git submodule update --init --recursive` to fetch them.
+- **Infra examples**: Live in the `examples/` directory.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Documentation**: [docs/](docs/README.md) – Configuration, object storage, installation, usage, and development. Log level can be set via `log_level` in config or `NEPTUNE_LOG_LEVEL` (DEBUG, INFO, ERROR).
 - **E2E tests**: [e2e/README.md](e2e/README.md) – Run against MinIO with `./e2e/run.sh` or `make e2e`
 - **Releases**: [github.com/devopsfactory-io/neptune/releases](https://github.com/devopsfactory-io/neptune/releases)
-- **Infra examples**: [examples/](examples/) – S3/GCS backend, automerge, Terramate stacks, Terragrunt (from [neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples); Git submodule — run `git submodule update --init --recursive` after clone to fetch).
+- **Infra examples**: [examples/](examples/) – S3/GCS backend, automerge, Terramate stacks, Terragrunt.
 - **neptbot**: Trigger Neptune from PR open and @-mention comments by [installing the neptbot GitHub App](docs/github-app-and-lambda.md) and adding the workflow (recommended). To self-host, see [lambda/](lambda/) and [lambda/README.md](lambda/README.md).
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md) – how to contribute; [docs/development.md](docs/development.md) and [AGENTS.md](AGENTS.md) for setup and AI/contributor guidance
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,4 @@ This folder contains detailed documentation for configuration, object storage, i
 | [Usage](usage.md) | CLI commands (`command plan/apply`, `unlock`) |
 | [GitHub App and Lambda](github-app-and-lambda.md) | Trigger Neptune via GitHub App webhooks and AWS Lambda (`repository_dispatch`) |
 | [Development](development.md) | Building, testing, and contributing |
-| [Examples](../examples/) | Sample configs and backends (S3, GCS, automerge, Terramate, Terragrunt) from the `examples` submodule |
+| [Examples](../examples/) | Sample configs and backends (S3, GCS, automerge, Terramate, Terragrunt) in `examples/` |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,8 @@
-# neptune-infra-examples
+# Neptune infrastructure examples
 
-Infrastructure examples for [Neptune](https://github.com/devopsfactory-io/neptune) (Terraform/OpenTofu PR automation with Terramate).
+Infrastructure examples for [Neptune](https://github.com/devopsfactory-io/neptune) (Terraform/OpenTofu PR automation with Terramate). These files live in the Neptune repo under `examples/`.
 
-This repository is intended to be used as the **examples** submodule of the Neptune repo; from Neptune root run `git submodule update --init --recursive` to fetch it.
-
-These examples show different ways to use [Neptune](https://github.com/devopsfactory-io/neptune) for Terraform/OpenTofu pull request automation: object storage backends (S3, GCS), PR automerge, Terramate stacks with Terraform, and Terragrunt with Terramate.
+They show different ways to use [Neptune](https://github.com/devopsfactory-io/neptune) for Terraform/OpenTofu pull request automation: object storage backends (S3, GCS), PR automerge, Terramate stacks with Terraform, and Terragrunt with Terramate.
 
 | Example | Description |
 |---------|-------------|
@@ -22,5 +20,4 @@ Neptune loads `.neptune.yaml` from the **default branch** of your repository in 
 
 ## Using these examples
 
-- **As a submodule from Neptune**: From the Neptune repo root, run `git submodule update --init --recursive` to fetch this repo into `examples/`. The examples listed above then live under `examples/examples/`.
-- **Standalone**: Clone [neptune-infra-examples](https://github.com/devopsfactory-io/neptune-infra-examples) and copy or adapt the example you need; set the required env vars and replace placeholder bucket names in `.neptune.yaml`.
+The examples are in this repo under `examples/` (e.g. `examples/s3-backend/`, `examples/automerge/`). Copy or adapt the example you need; set the required env vars and replace placeholder bucket names in `.neptune.yaml`.


### PR DESCRIPTION
## What is this feature?

Documentation updates: (1) remove all references to the neptune-infra-examples repository and the example sync script; (2) treat the `examples/` folder as part of the documentation so it is maintained when new features or config are delivered.

## Why do we need this feature?

The example sync to neptune-infra-examples is no longer needed. Examples now live only in this repo. To keep them useful, we want agents and contributors to consider and update `examples/` when adding or changing behavior, config, or workflows (same as README and docs/).

## Who is this feature for?

Contributors and AI agents: clearer docs surface (no obsolete sync/mirror), and consistent guidance to keep examples in sync with features.

## Related issues

<!-- None -->

## Notes for reviewers

- `.gitmodules` removed (submodule no longer used).
- Cursor rules and maintain-documentation skill now include `examples/` in the doc checklist and “when to update” guidance.

---

## Checklist

- [x] **Breaking changes?** No
- [x] **Documentation updated** (README, docs/, AGENTS.md, examples/README, .cursor rules/skills)
- [x] **Tests added or updated** N/A (docs only; `make test-all` passes)

---

## AI Summary

- **Scope:** docs, AGENTS.md, .cursor/rules, .cursor/skills, examples/README
- **Type:** docs
- **Key files/areas:** AGENTS.md, CONTRIBUTING.md, README.md, docs/README.md, examples/README.md, .cursor/rules/config-and-yaml.mdc, .cursor/rules/docs-and-ai-context.mdc, .cursor/skills/maintain-documentation/SKILL.md, .gitmodules (deleted)
