### PR TITLE
docs: add open source and CNCF readiness

### DIFF
--- a/.cursor/rules/go-standards.mdc
+++ b/.cursor/rules/go-standards.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Go Standards
 
-- **Format**: Use `gofmt -s`. Run `make check-fmt` before committing.
+- **Format**: Use `gofmt -s`. Run `make check-fmt` before committing. Use `git commit -s` for DCO sign-off (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 - **Lint**: Follow `.golangci.yml`; do not introduce new linter violations. Run `make lint` when available.
 - **Packages**: Code in `internal/` must not be imported from outside this module.
 - **Errors**: Always handle errors; add context with `fmt.Errorf("...: %w", err)` where useful.

--- a/.cursor/skills/maintain-documentation/SKILL.md
+++ b/.cursor/skills/maintain-documentation/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when:
 | examples/ | Humans | Copy-pasteable infra examples (S3/GCS, automerge, Terramate, Terragrunt); part of docs |
 | CONTRIBUTING.md | Humans | How to contribute; issue/PR templates, checklist, CI |
 | .github/pull_request_template.md | Humans + AI | PR description structure; includes AI Summary for reviewers |
-| .github/ISSUE_TEMPLATE/ | Humans | Bug report, feature request, staff issue templates |
+| .github/ISSUE_TEMPLATE/ | Humans | Bug report, feature request templates |
 | AGENTS.md | AI agents | Project overview, structure, setup, style, testing, CI, doc-update requirement |
 | .cursor/rules/*.mdc | AI agents | File-specific or always-applied rules (Go, CI, config, docs) |
 | .cursor/skills/*/SKILL.md | AI agents | Step-by-step workflows (e.g. maintain-documentation, release, open-pull-request) |

--- a/.cursor/skills/open-pull-request/SKILL.md
+++ b/.cursor/skills/open-pull-request/SKILL.md
@@ -25,7 +25,7 @@ Use this skill **only** when the user explicitly requests to open a pull request
 
 - Run `git add .`
 - **Commit message**: Use conventional style per project (e.g. `feat(scope): description`, `fix(scope): description`). If the user provided a message, use it; otherwise generate from `git status` and `git diff` (or `git diff --staged` after add).
-- Run `git commit -m "<message>"`
+- Run `git commit -s -m "<message>"` so the commit includes a Signed-off-by line (DCO). The repo has the [DCO bot](https://github.com/apps/dco) enabled; PRs must have all commits signed off.
 
 ### 3. Push and create PR
 

--- a/.github/ISSUE_TEMPLATE/4-staff-issues.md
+++ b/.github/ISSUE_TEMPLATE/4-staff-issues.md
@@ -1,5 +1,0 @@
----
-name: Staff issues
-about: Blank issue for Neptune staff members
-labels: internal
----

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Guidance for AI coding agents working on the Neptune project.
 - **`lambda/`** – AWS Lambda handler for Neptune GitHub App webhooks (verify signature, parse `pull_request`—including `labeled` when the added label is `NEPTUNE_PR_LABEL`—and `issue_comment`, trigger `repository_dispatch`; optional `NEPTUNE_PR_LABEL` gates on PR label). See [lambda/README.md](lambda/README.md).
 - **`lambda/cloudformation/`** – CloudFormation template to deploy the Lambda (Function URL, IAM, Secrets Manager). See [lambda/README.md](lambda/README.md#deploy-with-cloudformation).
 - **`Makefile`**, **`.golangci.yml`**, **`.goreleaser.yml`**, **`.github/workflows/`** – Build, test, lint, release.
+- **Root community docs**: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md), [GOVERNANCE.md](GOVERNANCE.md), [MAINTAINERS.md](MAINTAINERS.md), [ROADMAP.md](ROADMAP.md), [LICENSE](LICENSE).
 
 ---
 
@@ -120,7 +121,8 @@ PR titles may follow a conventional style (e.g. `feat(cmd): ...`, `fix(lock): ..
 
 ## References
 
-- **Contributing (human)**: [CONTRIBUTING.md](CONTRIBUTING.md) – main entry for contributors; issue and PR templates live in [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) and [.github/pull_request_template.md](.github/pull_request_template.md).
+- **Contributing (human)**: [CONTRIBUTING.md](CONTRIBUTING.md) – main entry for contributors; [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md); issue and PR templates in [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) and [.github/pull_request_template.md](.github/pull_request_template.md).
+- **Governance**: [GOVERNANCE.md](GOVERNANCE.md), [MAINTAINERS.md](MAINTAINERS.md), [ROADMAP.md](ROADMAP.md).
 - **Cursor rules**: `.cursor/rules/` – file-specific and always-applied rules.
 - **Cursor skills**: `.cursor/skills/` – workflows for documentation maintenance, releases, testing, and open-pull-request (open a PR from current changes via gh CLI).
 - **Neptune config**: [docs/configuration.md](docs/configuration.md) and [.neptune.example.yaml](.neptune.example.yaml) for `.neptune.yaml` schema; [docs/object-storage.md](docs/object-storage.md) for backend env vars.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+Neptune adopts the [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). By participating in this project, you agree to abide by its terms.
+
+## Summary
+
+We are committed to providing a welcoming and harassment-free experience for everyone. We expect all contributors and participants to be respectful and inclusive.
+
+## Reporting
+
+For incidents in the Neptune project community, you may contact the [CNCF Code of Conduct Committee](https://www.cncf.io/conduct/committee/) or report via the process described in the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md#reporting). You can expect a response within three business days.
+
+For detailed instructions, including how to submit a report anonymously, see the [CNCF Incident Resolution Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing. We welcome contributions and encourage you to open an issue or pull request.
 
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Getting started
 
 1. Fork the repository and clone your fork (infra examples are in the `examples/` directory).
@@ -14,10 +16,14 @@ Thank you for your interest in contributing. We welcome contributions and encour
 
 - **Bug reports** and **feature requests**: Use the [issue templates](.github/ISSUE_TEMPLATE/) when opening a new issue. Choose "Bug report" or "Feature request" as appropriate.
 - Search [existing issues](https://github.com/devopsfactory-io/neptune/issues) first to avoid duplicates.
-- For security vulnerabilities, please report them responsibly (e.g. via GitHub Security Advisories or as specified in the repository's security policy).
+- For **security vulnerabilities**, do not open a public issue. Please report them as described in our [Security Policy](SECURITY.md) (e.g. via [GitHub Security Advisories](https://github.com/devopsfactory-io/neptune/security/advisories/new)).
 
 ### Pull requests
 
+- **Sign-off (DCO)**: Your commits must comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). The [DCO bot](https://github.com/apps/dco) is enabled on this repository and will check that every commit has a `Signed-off-by` line matching the commit author.
+  - **Git config**: Set your name and email so the sign-off is valid: `git config user.name "Your Name"` and `git config user.email "you@example.com"` (use `--global` to set for all repos).
+  - **Adding sign-off**: Use `git commit -s` to add the line automatically. If you forgot, run `git commit --amend -s --no-edit` on the last commit.
+  - The DCO bot will comment on the PR with the status; fix any unsigned commits (e.g. amend and force-push) before merge.
 - Use the [pull request template](.github/pull_request_template.md). Fill in **What is this feature?**, **Why do we need this feature?**, and **Who is this feature for?** so the PR correlates with issues.
 - Link related issues in the "Related issues" section (e.g. `Fixes #123` or `Relates to #456`).
 - Complete the checklist before requesting review: breaking changes (if any), documentation updated, tests added or updated.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,37 @@
+# Governance
+
+This document describes how the Neptune project is governed and how you can become a maintainer.
+
+## Maintainers
+
+Maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md). They have write access to the repository and are responsible for:
+
+- Reviewing and merging pull requests
+- Triaging issues and guiding the roadmap
+- Releasing versions and maintaining compatibility
+- Upholding the [Code of Conduct](CODE_OF_CONDUCT.md) and [Security Policy](SECURITY.md)
+
+## Adding maintainers
+
+- New maintainers are proposed by existing maintainers (e.g. via a pull request that updates MAINTAINERS.md and optionally this file).
+- The proposal should briefly state the nominee’s contributions and why they are a good fit.
+- Existing maintainers reach consensus (e.g. lazy consensus over a short period; no formal vote required unless the group prefers it).
+- Once agreed, a maintainer updates MAINTAINERS.md and the nominee is granted the necessary access.
+
+We aim for maintainers from multiple organizations over time to keep the project neutral and sustainable.
+
+## Removing maintainers
+
+- A maintainer may step down at any time by opening a PR that moves them to the "Emeritus maintainers" section in MAINTAINERS.md.
+- If a maintainer is inactive for a long period (e.g. no substantial participation for 6+ months), other maintainers may propose moving them to emeritus after a brief check-in (e.g. an issue or private message).
+- Violations of the Code of Conduct or Security Policy are handled according to those documents and may result in removal; the CNCF Code of Conduct Committee may be involved for CoC matters.
+
+## Decision making
+
+- **Code and design**: Decisions are made through pull requests and issues. Maintainers review PRs and merge when there is consensus. Significant design or behavior changes should be discussed in an issue or PR description first.
+- **Releases**: A maintainer cuts a release (e.g. by pushing a version tag) following the process in [AGENTS.md](AGENTS.md#ci). There is no formal release committee; maintainers coordinate as needed.
+- **Disputes**: If maintainers disagree, they try to resolve it through discussion. If needed, they may involve a neutral third party (e.g. another maintainer or the CNCF, if the project is under the CNCF).
+
+## Community
+
+Everyone is welcome to contribute. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to contribute and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for expected behavior.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute
+          must include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!) The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+   Copyright 2024-2025 The Neptune Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,19 @@
+# Maintainers
+
+This file lists the maintainers of the Neptune project. Maintainers have write access to the repository and are responsible for reviewing and merging pull requests, triaging issues, and guiding the project.
+
+## Current maintainers
+
+| Name | GitHub | Role |
+|------|--------|------|
+| Kaio Fellipe | @kaio6fellipe | Maintainer |
+
+To add or update maintainers, open a pull request that updates this file. Changes are subject to approval by existing maintainers and follow the [GOVERNANCE.md](GOVERNANCE.md) process.
+
+## Emeritus maintainers
+
+Former maintainers who have stepped down are listed here with gratitude for their contributions.
+
+| Name | GitHub |
+|------|--------|
+| *None yet* | |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 ## Resources
 
+- **Code of Conduct**: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) – we adopt the CNCF Community Code of Conduct.
 - **Documentation**: [docs/](docs/README.md) – Configuration, object storage, installation, usage, and development. Log level can be set via `log_level` in config or `NEPTUNE_LOG_LEVEL` (DEBUG, INFO, ERROR).
 - **E2E tests**: [e2e/README.md](e2e/README.md) – Run against MinIO with `./e2e/run.sh` or `make e2e`
 - **Releases**: [github.com/devopsfactory-io/neptune/releases](https://github.com/devopsfactory-io/neptune/releases)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+# Roadmap
+
+This document outlines the high-level direction for Neptune. It is living documentation and may be updated as priorities evolve.
+
+## Vision
+
+Neptune aims to be a reliable, community-friendly tool for Terraform and OpenTofu pull request automation that fits well in CI and works with Terramate for change detection and run order.
+
+## Current focus
+
+- **Stability**: Keep the core plan/apply workflow, locking, and PR integration solid.
+- **Documentation**: Improve configuration, installation, and usage docs so new users can adopt Neptune easily.
+- **Compatibility**: Support current Terraform and OpenTofu versions and Terramate SDK evolution.
+
+## Possible future directions
+
+- **Ecosystem**: Deeper integration or documentation for common backends and workflows (e.g. more object stores, CI systems).
+- **Observability**: Optional metrics or logging improvements for operators.
+- **Community**: Grow maintainers and contributors from multiple organizations.
+
+## Releases
+
+Release cadence and versioning follow [semantic versioning](https://semver.org/). See [Releases](https://github.com/devopsfactory-io/neptune/releases) for history and [AGENTS.md](AGENTS.md) for the release process.
+
+## Feedback
+
+If you have ideas or priorities you’d like to see on the roadmap, open an [issue](https://github.com/devopsfactory-io/neptune/issues) or start a [discussion](https://github.com/devopsfactory-io/neptune/discussions) (if enabled).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+We provide security updates for the current major release and the previous major release. See the [Releases](https://github.com/devopsfactory-io/neptune/releases) page for version history.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest release (see [Releases](https://github.com/devopsfactory-io/neptune/releases)) | :white_check_mark: |
+| Older releases | :x: |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you believe you have found a security vulnerability, please report it responsibly.
+
+**Preferred method:** Use [GitHub Security Advisories](https://github.com/devopsfactory-io/neptune/security/advisories/new) (private disclosure). This keeps the report confidential until a fix is ready.
+
+**Alternative:** Email the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md) (use the contact method they provide, if any). Do not open a public issue for security vulnerabilities.
+
+### What to include
+
+- Description of the problem
+- Steps to reproduce (as precise as possible)
+- Affected version(s)
+- Possible mitigations, if known
+
+### What to expect
+
+- We will acknowledge receipt within a few business days.
+- We may follow up to clarify or confirm the issue.
+- We will work on a fix and coordinate disclosure (e.g. release + advisory) when appropriate.
+
+We do not have a formal embargo policy; we handle disclosure in a reasonable, coordinated way.
+
+## Security Considerations
+
+- Neptune runs Terraform/OpenTofu and interacts with object storage (GCS, S3) and GitHub. Ensure credentials (e.g. `GITHUB_TOKEN`, cloud credentials) are scoped and stored securely.
+- In CI, config is loaded from the repository default branch to limit impact of malicious PR changes to workflow steps.
+- For deployment and hardening guidance, see [docs/installation.md](docs/installation.md) and [docs/configuration.md](docs/configuration.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Contributing workflow (issues, pull requests, checklist) is described in [CONTRIBUTING.md](../CONTRIBUTING.md).
+Contributing workflow (issues, pull requests, checklist) is described in [CONTRIBUTING.md](../CONTRIBUTING.md). For pull requests, ensure your commits are signed off (DCO); see the [Sign-off (DCO)](../CONTRIBUTING.md#pull-requests) section for git config and `git commit -s`.
 
 ## End-to-end tests
 


### PR DESCRIPTION
## What is this feature?

Adds the documentation and policy files required to open source Neptune and to align with CNCF sandbox application requirements: license, code of conduct, security policy, maintainers, roadmap, and governance. Also documents DCO sign-off and updates contributor/agent guidance.

## Why do we need this feature?

To make the repository ready for going public and for a future CNCF sandbox application. The plan covered Phase 1 (critical) and Phase 2 (important) items: LICENSE, CODE_OF_CONDUCT.md, SECURITY.md, MAINTAINERS.md, ROADMAP.md, GOVERNANCE.md, CONTRIBUTING/README/AGENTS updates, DCO documentation, and removal of the staff-only issue template.

## Who is this feature for?

Maintainers and contributors; anyone evaluating the project for adoption or CNCF submission.

## Related issues

<!-- None -->

## Notes for reviewers

- MAINTAINERS.md has a placeholder row; maintainers should fill in names/GitHub IDs before or after merge.
- Making the repo public is a separate GitHub setting (not in this PR).
- DCO app is enabled at org level; CONTRIBUTING and open-pull-request skill now use `git commit -s`.

---

## Checklist

- [x] **Breaking changes?** No
- [x] **Documentation updated** (README, docs/, CONTRIBUTING, AGENTS.md, .cursor skills/rules)
- [x] **Tests added or updated** (N/A for docs; `make test-all` passes)

---

## AI Summary

- **Scope:** docs, root community files (LICENSE, CoC, SECURITY, GOVERNANCE, MAINTAINERS, ROADMAP), CONTRIBUTING, README, AGENTS.md, .cursor/skills (open-pull-request, maintain-documentation), .cursor/rules (go-standards), .github/ISSUE_TEMPLATE
- **Type:** docs
- **Key files/areas:** LICENSE, CODE_OF_CONDUCT.md, SECURITY.md, MAINTAINERS.md, ROADMAP.md, GOVERNANCE.md, CONTRIBUTING.md, README.md, AGENTS.md, docs/development.md, .cursor/skills/open-pull-request/SKILL.md, .cursor/rules/go-standards.mdc
