### PR TITLE
chore(ci): add Renovate bot config (Atlantis-style)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,12 @@
 neptune:
   - changed-files:
     - any-glob-to-any-file: '**'
+# Apply "dependencies" when dependency-related files change (Renovate PRs).
+dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+        - 'go.mod'
+        - 'go.sum'
+        - 'lambda/go.mod'
+        - 'lambda/go.sum'
+        - '.github/workflows/**/*.yml'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,46 @@
+{
+  extends: [
+    'config:best-practices',
+    ':separateMultipleMajorReleases',
+    'schedule:daily',
+    'security:openssf-scorecard',
+  ],
+  commitMessageSuffix: ' in {{packageFile}}',
+  dependencyDashboardAutoclose: true,
+  automerge: true,
+  baseBranchPatterns: ['main', '/^release-.*/'],
+  platformAutomerge: true,
+  labels: ['dependencies'],
+  postUpdateOptions: ['gomodTidy', 'gomodUpdateImportPaths'],
+  prHourlyLimit: 1,
+  minimumReleaseAge: '5 days',
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    enabled: true,
+    labels: ['security'],
+  },
+  packageRules: [
+    // Enable release branches for security updates only
+    {
+      matchBaseBranches: ['/^release-.*/'],
+      matchUpdateTypes: ['security'],
+      enabled: true,
+    },
+    // Disable release branches for non-security updates
+    {
+      matchBaseBranches: ['/^release-.*/'],
+      enabled: false,
+    },
+    // Go version (actions/setup-go, go.mod)
+    {
+      matchPackageNames: ['go', 'golang'],
+      versioning: 'go',
+      groupName: 'go',
+    },
+    // GitHub Actions
+    {
+      matchPackageNames: ['/github-actions/'],
+      groupName: 'github-',
+    },
+  ],
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ Use Go version from `go.mod`. No other prerequisites for building or testing the
 - **`.github/workflows/integration.yml`** – On PRs when integration-relevant paths change; runs Neptune plan/apply on the same PR with real GitHub (requirements check, PR comments, commit statuses) and MinIO for locks. Needs `statuses: write` for commit status API. See [e2e/README.md](e2e/README.md#integration-tests).
 - **`.github/workflows/lint.yml`** – On PRs; path filter for Go; runs golangci-lint.
 - **`.github/workflows/release.yml`** – On push of tags `v*.*.*` (and workflow_dispatch); runs GoReleaser to create GitHub Release and binaries.
+- **Renovate** – Dependency-update PRs (Go modules and GitHub Actions) are opened by [Renovate](https://docs.renovatebot.com/) from [.github/renovate.json5](.github/renovate.json5). Do not remove or override this config without reason.
 
 Semantic versioning: use tags like `v0.2.0`. GoReleaser injects version/commit/date into the binary via ldflags.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - **Infra examples**: [examples/](examples/) – S3/GCS backend, automerge, Terramate stacks, Terragrunt.
 - **neptbot**: Trigger Neptune from PR open and @-mention comments by [installing the neptbot GitHub App](docs/github-app-and-lambda.md) and adding the workflow (recommended). To self-host, see [lambda/](lambda/) and [lambda/README.md](lambda/README.md).
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md) – how to contribute; [docs/development.md](docs/development.md) and [AGENTS.md](AGENTS.md) for setup and AI/contributor guidance
+- **Dependencies**: [Renovate](https://docs.renovatebot.com/) opens PRs for Go modules and GitHub Actions updates (see [.github/renovate.json5](.github/renovate.json5)).
 
 ## What is Neptune?
 


### PR DESCRIPTION
## What is this feature?

Add Renovate bot configuration so dependency updates (Go modules and GitHub Actions) are opened as PRs on a schedule, with optional automerge and security alerts, matching the setup used in the [Atlantis](https://github.com/runatlantis/atlantis) project.

## Why do we need this feature?

To keep dependencies up to date automatically without manual checks; Renovate opens PRs for outdated Go modules (root and lambda) and GitHub Action versions, with security vulnerability alerts and consistent labeling.

## Who is this feature for?

Maintainers and contributors; dependency-update PRs can be reviewed and merged like any other PR (or automerged when checks pass).

## Related issues

<!-- None -->

## Notes for reviewers

- Config lives in `.github/renovate.json5`. To activate, install the [Renovate GitHub App](https://github.com/apps/renovate) on this repo.
- Release branches get only security updates; other updates target `main`. Labels `dependencies` and `security` are applied by Renovate; the labeler also applies `dependencies` when dependency-related files change.

---

## Checklist

- [ ] **Breaking changes?** No
- [x] **Documentation updated** (README, docs/, or `.neptune.example.yaml` as needed)
- [x] **Tests added or updated** (`make test-all` passes) — config only; no code changes

---

## AI Summary

- **Scope:** .github (renovate, labeler), README, AGENTS.md
- **Type:** chore
- **Key files/areas:** .github/renovate.json5, .github/labeler.yml, README.md, AGENTS.md
