### PR TITLE
ci(workflows): trigger e2e and integration on go.mod/go.sum changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,7 @@ jobs:
               - 'docker-compose*.yaml'
               - 'docker-compose*.yml'
               - '.github/workflows/e2e.yml'
+              - 'go.*'
 
   e2e:
     needs: [changes]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,6 +41,7 @@ jobs:
               - 'docker-compose*.yml'
               - '.github/workflows/integration.yml'
               - '.github/workflows/neptune.yml'
+              - 'go.*'
 
   integration:
     needs: [changes]


### PR DESCRIPTION
## What is this feature?

Add `go.*` to the path filters in the e2e and integration workflows so they run when `go.mod` or `go.sum` change (in addition to existing triggers).

## Why do we need this feature?

When Go dependencies change, e2e and integration tests should run to catch regressions. Previously, only Go source paths and a fixed set of config/docker/workflow paths triggered these jobs; dependency changes could be merged without running these workflows.

## Who is this feature for?

Maintainers and contributors: dependency updates (e.g. Renovate) or manual go mod changes will now trigger e2e and integration CI.

## Related issues

<!-- e.g. Fixes #123 or Relates to #456 -->

## Notes for reviewers

Path filter uses `go.*` to match both `go.mod` and `go.sum` in one pattern.

---

## Checklist

- [ ] **Breaking changes?** No
- [ ] **Documentation updated** (README, docs/, or `.neptune.example.yaml` as needed) N/A
- [ ] **Tests added or updated** (`make test-all` passes) N/A (workflow-only change)

---

## AI Summary

- **Scope:** `.github/workflows` (e2e.yml, integration.yml)
- **Type:** ci
- **Key files/areas:** `.github/workflows/e2e.yml`, `.github/workflows/integration.yml`
