### PR TITLE
chore(ci): disable concurrency in GitHub workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,9 +11,9 @@ on:
       - main
       - "release-**"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+#   cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,9 +11,9 @@ on:
       - main
       - "release-**"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: false
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+#   cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,9 @@ on:
       - main
       - "release-**"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+#   cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/neptune.yml
+++ b/.github/workflows/neptune.yml
@@ -7,9 +7,9 @@ on:
   repository_dispatch:
     types: [neptune-command]
 
-concurrency:
-  group: neptune-${{ github.event.client_payload.pull_request_number }}
-  cancel-in-progress: false
+# concurrency:
+#   group: neptune-${{ github.event.client_payload.pull_request_number }}
+#   cancel-in-progress: false
 
 permissions:
   pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ on:
       - main
       - "release-**"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+#   cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## What is this feature?

Disables (comments out) the `concurrency` configuration in all five GitHub Actions workflows (e2e, integration, lint, neptune, test) so that multiple workflow runs can proceed in parallel instead of being grouped/cancelled by concurrency.

## Why do we need this feature?

Concurrency groups were limiting parallel runs (e.g. one run per PR per workflow). Commenting them out allows multiple runs to proceed without cancelling in-progress jobs, which can be useful for faster feedback or debugging CI.

## Who is this feature for?

Developers and maintainers running CI; anyone who wants workflow runs to not be serialized or cancelled by concurrency.

## Related issues

<!-- None -->

## Notes for reviewers

Concurrency blocks are commented out rather than removed so they can be re-enabled easily if needed. No functional change to job steps themselves.

---

## Checklist

- [ ] **Breaking changes?** No
- [ ] **Documentation updated** N/A (CI-only change)
- [ ] **Tests added or updated** N/A (CI config only)

---

## AI Summary

- **Scope:** `.github/workflows/` (e2e, integration, lint, neptune, test)
- **Type:** chore / refactor
- **Key files/areas:** `.github/workflows/e2e.yml`, `.github/workflows/integration.yml`, `.github/workflows/lint.yml`, `.github/workflows/neptune.yml`, `.github/workflows/test.yml`
