### PR TITLE
docs: require signed-off commits (DCO) in AGENTS.md and Cursor rule

### DIFF
--- a/.cursor/rules/commits-dco.mdc
+++ b/.cursor/rules/commits-dco.mdc
@@ -1,0 +1,11 @@
+---
+description: Every commit must be signed off (DCO). Use git commit -s. Never commit without sign-off.
+alwaysApply: true
+---
+
+# Commits and DCO (Developer Certificate of Origin)
+
+- **Sign-off is required**: Every commit in this repository must include a `Signed-off-by` line (DCO). The DCO bot checks this on PRs.
+- **When committing**: Always use `git commit -s` (the `-s` flag adds the sign-off automatically). For example: `git commit -s -m "fix: message"`.
+- **If you already committed without sign-off**: Run `git commit --amend -s --no-edit`, then `git push --force-with-lease` (or push with force as appropriate for the branch).
+- **Human contributors**: See [CONTRIBUTING.md](CONTRIBUTING.md) for full DCO and git config instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,9 +113,10 @@ Do not edit plan files (e.g. `neptune_go_rewrite*.plan.md` or `ai_agent_config*.
 
 Before submitting:
 
-1. Run `make test-all` and `make check-fmt`.
-2. Ensure no new linter errors (`make lint` if available).
-3. If behavior or setup changed, update README, docs/, examples/, and/or AGENTS.md and rules/skills as above.
+1. **Commits must be signed off (DCO).** Use `git commit -s` when creating commits. If you already committed without sign-off, run `git commit --amend -s --no-edit` then force-push. See [CONTRIBUTING.md](CONTRIBUTING.md) and the `.cursor/rules/commits-dco.mdc` rule.
+2. Run `make test-all` and `make check-fmt`.
+3. Ensure no new linter errors (`make lint` if available).
+4. If behavior or setup changed, update README, docs/, examples/, and/or AGENTS.md and rules/skills as above.
 
 PR titles may follow a conventional style (e.g. `feat(cmd): ...`, `fix(lock): ...`, `docs: ...`) but this is not enforced.
 


### PR DESCRIPTION
## What is this feature?

Documentation and Cursor rule so that every commit is signed off (DCO): AGENTS.md PR Guidance now lists sign-off as the first step, and a new always-applied rule (`.cursor/rules/commits-dco.mdc`) reminds agents to use `git commit -s` and how to fix missing sign-off.

## Why do we need this feature?

The repo uses the DCO bot; PRs require all commits to have a `Signed-off-by` line. It is easy to forget to use `-s` when committing. This change makes sign-off impossible to forget for AI agents (always-applied rule + AGENTS.md) and keeps human instructions in CONTRIBUTING.md.

## Who is this feature for?

Contributors and AI agents working on Neptune: anyone who commits so that PRs pass DCO checks.

## Related issues

<!-- None -->

## Notes for reviewers

- CONTRIBUTING.md already had the full DCO section; no change there.
- The new rule uses `alwaysApply: true` so it is always in context when the agent considers committing.

---

## Checklist

- [ ] **Breaking changes?** No
- [x] **Documentation updated** (AGENTS.md, new .cursor rule)
- [x] **Tests added or updated** (N/A – docs only; `make test-all` passes)

---

## AI Summary

- **Scope:** docs, AGENTS.md, .cursor/rules
- **Type:** docs
- **Key files/areas:** AGENTS.md (PR Guidance), .cursor/rules/commits-dco.mdc (new)
