### PR TITLE
feat(ci): build Lambda in GoReleaser and document release process

### DIFF
--- a/.cursor/rules/ci-and-release.mdc
+++ b/.cursor/rules/ci-and-release.mdc
@@ -11,4 +11,4 @@ alwaysApply: false
 - **integration.yml**: Runs Neptune plan/apply on PRs with real GitHub and MinIO. Needs `statuses: write` so Neptune can set commit statuses (neptune plan / neptune apply).
 - **release.yml**: Triggers on push of tags `v*.*.*`. Uses GoReleaser; needs `contents: write`. Do not change tag pattern or permissions without good reason.
 - **Semver**: Tags are `vMAJOR.MINOR.PATCH` (e.g. `v0.2.0`). GoReleaser reads tag and injects version/commit/date via ldflags in `main.go`.
-- **.goreleaser.yml**: Builds single binary `neptune` from `.`; multi-OS/arch. Do not remove ldflags or rename binary without updating docs.
+- **.goreleaser.yml**: Builds `neptune` binary from `.` (multi-OS/arch) and Lambda `bootstrap` from `lambda/` (linux/amd64, released as `neptune-webhook.zip`). Changelog is auto-generated (e.g. `use: github`). Do not remove ldflags or rename binaries without updating docs.

--- a/.cursor/skills/release-and-versioning/SKILL.md
+++ b/.cursor/skills/release-and-versioning/SKILL.md
@@ -16,12 +16,12 @@ description: Cuts a new release with semantic versioning and GoReleaser. Use whe
 2. **Create and push the tag**:
    - `git tag vX.Y.Z`
    - `git push origin vX.Y.Z`
-3. **Let CI run** – `.github/workflows/release.yml` runs on tag push. GoReleaser creates the GitHub Release and uploads binaries (see `.goreleaser.yml`).
+3. **Let CI run** – `.github/workflows/release.yml` runs on tag push. GoReleaser creates the GitHub Release with neptune binaries, `neptune-webhook.zip` (Lambda), and auto-generated changelog (see `.goreleaser.yml`).
 4. **Do not run destructive commands** (e.g. `git push` or creating tags) without user confirmation.
 
 ## GoReleaser
 
-- **.goreleaser.yml**: Builds a single binary `neptune` from the repo root. Ldflags set `main.version`, `main.commit`, `main.date`. Produces archives (tar.gz, zip) and checksums for multiple OS/arch.
+- **.goreleaser.yml**: Builds `neptune` from the repo root (ldflags set `main.version`, `main.commit`, `main.date`) and Lambda `bootstrap` from `lambda/` (released as `neptune-webhook.zip`). Produces archives (tar.gz, zip) and checksums; changelog is auto-generated (e.g. `use: github`).
 - **release.yml**: Uses `goreleaser/goreleaser-action` with `release --clean` and `contents: write` permission.
 
 If the user only wants to understand the workflow, explain the steps and point to `.goreleaser.yml` and `.github/workflows/release.yml` without running any commands.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,5 +42,10 @@
       matchPackageNames: ['/github-actions/'],
       groupName: 'github-',
     },
+    // Ignore timestamp-authority v2 until indirect deps support it
+    {
+      matchPackageNames: ['github.com/sigstore/timestamp-authority/v2'],
+      enabled: false,
+    },
   ],
 }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
+    - cd lambda && go mod tidy
 
 builds:
   - id: neptune
@@ -24,8 +25,19 @@ builds:
       - goos: windows
         goarch: arm64
 
+  - id: lambda
+    dir: lambda
+    main: .
+    binary: bootstrap
+    goos:
+      - linux
+    goarch:
+      - amd64
+
 archives:
-  - format: tar.gz
+  - ids:
+      - neptune
+    format: tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -36,10 +48,18 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    rlcp: true
+
+  - id: lambda-archive
+    ids:
+      - lambda
+    format: zip
+    name_template: neptune-webhook
+    strip_binary_directory: true
+    wrap_in_directory: false
 
 checksum:
   name_template: checksums.txt
 
 changelog:
-  skip: true
+  use: github
+  sort: asc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Use Go version from `go.mod`. No other prerequisites for building or testing the
 - **`.github/workflows/e2e.yml`** – On push/PR when e2e-related paths change; runs `./e2e/scripts/run-terramate.sh` with MinIO (Docker Compose). See [e2e/README.md](e2e/README.md).
 - **`.github/workflows/integration.yml`** – On PRs when integration-relevant paths change; runs Neptune plan/apply on the same PR with real GitHub (requirements check, PR comments, commit statuses) and MinIO for locks. Needs `statuses: write` for commit status API. See [e2e/README.md](e2e/README.md#integration-tests).
 - **`.github/workflows/lint.yml`** – On PRs; path filter for Go; runs golangci-lint.
-- **`.github/workflows/release.yml`** – On push of tags `v*.*.*` (and workflow_dispatch); runs GoReleaser to create GitHub Release and binaries.
+- **`.github/workflows/release.yml`** – On push of tags `v*.*.*` (and workflow_dispatch); runs GoReleaser to create GitHub Release with neptune binaries, Lambda zip (`neptune-webhook.zip`), and auto-generated changelog.
 - **Renovate** – Dependency-update PRs (Go modules and GitHub Actions) are opened by [Renovate](https://docs.renovatebot.com/) from [.github/renovate.json5](.github/renovate.json5). To enable Renovate, install the [Renovate GitHub App](https://github.com/apps/renovate) and select the repo. Do not remove or override this config without reason.
 
 Semantic versioning: use tags like `v0.2.0`. GoReleaser injects version/commit/date into the binary via ldflags.

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,3 +16,51 @@ make lint       # run golangci-lint (optional)
 ```
 
 Use the Go version from `go.mod`. See [AGENTS.md](../AGENTS.md) for code style, testing, and CI.
+
+## Release Process
+
+Neptune uses semantic versioning and [GoReleaser](https://goreleaser.com/) to create releases. Only maintainers with push access can create releases.
+
+### Semantic Versioning
+
+Tags follow the pattern `vMAJOR.MINOR.PATCH` (e.g., `v0.2.0`, `v1.0.0`). The `v` prefix is required.
+
+- **MAJOR**: Breaking changes or significant architectural changes
+- **MINOR**: New features, backward-compatible
+- **PATCH**: Bug fixes, backward-compatible
+
+### Creating a Release
+
+1. **Ensure CI is green**: All tests, linting, and checks must pass on `main` (or the branch you're releasing from).
+
+2. **Create and push the tag**:
+
+   ```bash
+   git tag v0.3.0
+   git push origin v0.3.0
+   ```
+
+3. **GoReleaser runs automatically**: The [`.github/workflows/release.yml`](../.github/workflows/release.yml) workflow triggers on tag push and runs GoReleaser with the configuration from [`.goreleaser.yml`](../.goreleaser.yml).
+
+4. **Release artifacts**: GoReleaser creates a [GitHub Release](https://github.com/devopsfactory-io/neptune/releases) with:
+   - `neptune` binaries for multiple OS/arch (Linux, macOS, Windows; amd64, arm64)
+   - `neptune-webhook.zip` (AWS Lambda handler for the GitHub App)
+   - `checksums.txt` (SHA256 checksums for all artifacts)
+   - Auto-generated changelog from commit messages since the previous tag
+
+The version, commit SHA, and build date are injected into the binary via ldflags at build time (see `main.version`, `main.commit`, `main.date`).
+
+### Manual Release (if needed)
+
+If you need to run GoReleaser locally (e.g., for testing or troubleshooting), ensure you have [GoReleaser installed](https://goreleaser.com/install/) and a `GITHUB_TOKEN` with `contents: write` permission:
+
+```bash
+export GITHUB_TOKEN=your_token_here
+goreleaser release --clean
+```
+
+For a dry run without publishing:
+
+```bash
+goreleaser release --snapshot --clean
+```

--- a/go.mod
+++ b/go.mod
@@ -164,7 +164,7 @@ require (
 	github.com/sigstore/rekor v1.5.0 // indirect
 	github.com/sigstore/rekor-tiles v0.1.11 // indirect
 	github.com/sigstore/sigstore v1.10.4 // indirect
-	github.com/sigstore/timestamp-authority/v2 v2.0.3 // indirect
+	github.com/sigstore/timestamp-authority v1.2.9 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
@@ -213,5 +213,4 @@ require (
 	google.golang.org/grpc v1.79.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1642,8 +1642,8 @@ github.com/sigstore/sigstore v1.10.4 h1:ytOmxMgLdcUed3w1SbbZOgcxqwMG61lh1TmZLN+W
 github.com/sigstore/sigstore v1.10.4/go.mod h1:tDiyrdOref3q6qJxm2G+JHghqfmvifB7hw+EReAfnbI=
 github.com/sigstore/sigstore-go v1.1.3 h1:5lKcbXZa5JC7wb/UVywyCulccfYTUju1D5h4tkn+fXE=
 github.com/sigstore/sigstore-go v1.1.3/go.mod h1:3jKC4IDh7TEVtCSJCjx0lpq5YfJbDJmfp65WsMvY2mg=
-github.com/sigstore/timestamp-authority v1.2.8 h1:BEV3fkphwU4zBp3allFAhCqQb99HkiyCXB853RIwuEE=
-github.com/sigstore/timestamp-authority v1.2.8/go.mod h1:G2/0hAZmLPnevEwT1S9IvtNHUm9Ktzvso6xuRhl94ZY=
+github.com/sigstore/timestamp-authority v1.2.9 h1:L9Fj070/EbMC8qUk8BchkrYCS1BT5i93Bl6McwydkFs=
+github.com/sigstore/timestamp-authority v1.2.9/go.mod h1:QyRnZchz4o+xdHyK5rvCWacCHxWmpX+mgvJwB1OXcLY=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/lambda/README.md
+++ b/lambda/README.md
@@ -29,6 +29,8 @@ zip neptune-webhook.zip bootstrap
 
 From the repository root you can run `make lambda.build` and `make lambda.zip`. The binary must be named `bootstrap` for the `provided.al2023` runtime. Run `make lambda.test` to execute the Lambda unit tests.
 
+Each [GitHub Release](https://github.com/devopsfactory-io/neptune/releases) includes a pre-built `neptune-webhook.zip` (and checksums) so you can download it instead of building locally.
+
 ## Deploy with CloudFormation
 
 1. **Create two secrets in AWS Secrets Manager** (in the same region/account where you will deploy the stack):


### PR DESCRIPTION
## What is this feature?

This PR adds Lambda build support to GoReleaser, so neptune-webhook.zip is automatically created and published with each GitHub Release. It also documents the complete release process for maintainers.

## Why do we need this feature?

Previously, the Lambda function had to be built manually (make lambda.build, make lambda.zip). This change automates Lambda builds in the release workflow, making it easier for users to download pre-built Lambda packages from GitHub Releases and for maintainers to publish complete releases with a single tag push.

## Who is this feature for?

- **Users**: Can now download pre-built neptune-webhook.zip from GitHub Releases instead of building locally
- **Maintainers**: Have a documented, automated release process with Lambda builds included

## Related issues

N/A

## Notes for reviewers

- .goreleaser.yml now has two builds: "neptune" (main CLI) and "lambda" (bootstrap binary)
- Lambda archive is named neptune-webhook.zip (strip_binary_directory for clean zip structure)
- Added Renovate ignore rule for sigstore/timestamp-authority/v2 due to indirect dependency compatibility issues
- docs/development.md now includes comprehensive release documentation (semantic versioning, tag creation, GoReleaser workflow)

---

## Checklist

- [ ] **Breaking changes?** No
- [x] **Documentation updated** (docs/development.md added release process; lambda/README.md updated with download info)
- [x] **Tests added or updated** (no code logic changes; make test-all passes)

---

## AI Summary

- **Scope:** ci (goreleaser, release workflow), docs (development.md, lambda/README.md), AGENTS.md, cursor rules/skills
- **Type:** feat
- **Key files/areas:** .goreleaser.yml, docs/development.md, lambda/README.md, .github/renovate.json5, AGENTS.md, .cursor/rules/ci-and-release.mdc, .cursor/skills/release-and-versioning/SKILL.md