### PR TITLE
feat(release): changelog format with commit links and @username

### DIFF
--- a/.cursor/skills/release-and-versioning/SKILL.md
+++ b/.cursor/skills/release-and-versioning/SKILL.md
@@ -21,7 +21,7 @@ description: Cuts a new release with semantic versioning and GoReleaser. Use whe
 
 ## GoReleaser
 
-- **.goreleaser.yml**: Builds `neptune` from the repo root (ldflags set `main.version`, `main.commit`, `main.date`) and Lambda `neptune-webhook` from `lambda/` (released as `neptune-webhook.zip` and raw `neptune-webhook_linux_amd64`). Produces lowercase-named archives (e.g. `neptune_linux_amd64.tar.gz`), raw binaries, and checksums; changelog is grouped (Breaking Changes, Features, Bug fixes, etc.) with release footer linking to full changelog.
+- **.goreleaser.yml**: Builds `neptune` from the repo root (ldflags set `main.version`, `main.commit`, `main.date`) and Lambda `neptune-webhook` from `lambda/` (released as `neptune-webhook.zip` and raw `neptune-webhook_linux_amd64`). Produces lowercase-named archives (e.g. `neptune_linux_amd64.tar.gz`), raw binaries, and checksums; changelog is grouped (Breaking Changes, Features, Bug fixes, etc.) with a custom format: commit hash as link to commit, authors as @username; PR refs (#N) in messages are autolinked by GitHub. Release footer links to full changelog.
 - **release.yml**: Uses `goreleaser/goreleaser-action` with `release --clean` and `contents: write` permission.
 
 ## Breaking changes and changelog

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,6 +85,9 @@ release:
 
 changelog:
   use: github
+  # Commit as link; author as @username (Logins). PR refs (#N) are autolinked by GitHub in release body.
+  # Repo fallback used when Env is not available in changelog format context (e.g. devopsfactory-io/neptune).
+  format: "[{{ .SHA }}](https://github.com/{{ if .Env.GORELEASER_CURRENT_REPOSITORY }}{{ .Env.GORELEASER_CURRENT_REPOSITORY }}{{ else }}devopsfactory-io/neptune{{ end }}/commit/{{ .SHA }}): {{ .Message }}{{ if .Logins }} ({{ .Logins | englishJoin }}){{ end }}"
   sort: asc
   abbrev: 7
   groups:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Use Go version from `go.mod`. No other prerequisites for building or testing the
 
 Semantic versioning: use tags like `v0.2.0`. GoReleaser injects version/commit/date into the binary via ldflags.
 
-**Changelog and breaking changes**: The release changelog is grouped by conventional-commit type (Breaking Changes, Features, Bug fixes, etc.). For a release that includes **breaking changes**, use the conventional `!` before `:` in the commit subject so those commits appear under "Breaking Changes" (e.g. `feat!: remove deprecated flag`, `fix(config)!: change default behavior`). Without `!:` in the subject, the commit is grouped by type (e.g. feat/fix) but not under Breaking Changes.
+**Changelog and breaking changes**: The release changelog is grouped by conventional-commit type (Breaking Changes, Features, Bug fixes, etc.). Each line uses a custom format: commit hash is a link to the commit, authors are shown as @username, and PR refs (e.g. #5) in the message are autolinked by GitHub in the release body. For a release that includes **breaking changes**, use the conventional `!` before `:` in the commit subject so those commits appear under "Breaking Changes" (e.g. `feat!: remove deprecated flag`, `fix(config)!: change default behavior`). Without `!:` in the subject, the commit is grouped by type (e.g. feat/fix) but not under Breaking Changes.
 
 ---
 


### PR DESCRIPTION
## What is this feature?

Custom GoReleaser changelog format so release notes show the commit hash as a clickable link to the commit, authors as @username (e.g. @kaio6fellipe), and keep PR refs (e.g. #5) in the message so GitHub autolinks them in the release body.

## Why do we need this feature?

v0.1.0 release notes had plain commit SHAs (no link), full name/email instead of @username, and no explicit PR links. This improves readability and makes commits and contributors easy to click through from the changelog.

## Who is this feature for?

Maintainers cutting releases and anyone reading the GitHub Release changelog.

## Related issues

<!-- e.g. Fixes #123 or Relates to #456 -->

N/A

## Notes for reviewers

- Changelog format uses `GORELEASER_CURRENT_REPOSITORY` from env (set in release.yml); a fallback repo `devopsfactory-io/neptune` is used in the template when Env is not available in the changelog format context.
- PR links: we rely on GitHub autolinking `#N` in the same-repo release body; no script or Pro feature added.

---

## Checklist

- [x] **Breaking changes?** No
- [x] **Documentation updated** (README, docs/, or `.neptune.example.yaml` as needed) — AGENTS.md and release skill updated
- [x] **Tests added or updated** (`make test-all` passes) — N/A (config and docs only; `goreleaser check` validates)

---

## AI Summary

- **Scope:** release (GoReleaser changelog), AGENTS.md, .cursor/skills/release-and-versioning
- **Type:** feat
- **Key files/areas:** .goreleaser.yml (changelog.format), AGENTS.md (changelog and breaking changes), .cursor/skills/release-and-versioning/SKILL.md (GoReleaser bullet)
