### PR TITLE
fix(ci): use resolvable checkout ref in label-old-prs workflow

### DIFF
--- a/.github/workflows/label-old-prs.yml
+++ b/.github/workflows/label-old-prs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901aee4e7506a1a2a2361e5b2e2b76a9bd # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get PR numbers
         id: prs
         run: |


### PR DESCRIPTION
## What is this feature?

Fix the "Label old PRs" workflow so it no longer fails when resolving the `actions/checkout` action.

## Why do we need this feature?

The workflow was pinned to an old `actions/checkout` v4 SHA that GitHub can no longer resolve (error: "An action could not be found at the URI ..."). Updating to the same checkout ref (v6) used by other workflows in the repo fixes the failure.

## Who is this feature for?

Maintainers who run the manual "Label old PRs" workflow to apply current labeler rules to existing/merged PRs.

## Related issues

<!-- e.g. Fixes #123 or Relates to #456 -->

## Notes for reviewers

Single-line change: `actions/checkout` ref updated from v4 SHA to the v6 SHA already used in test.yml, e2e.yml, integration.yml, release.yml, and lint.yml.

---

## Checklist

- [x] **Breaking changes?** No
- [x] **Documentation updated** N/A (workflow-only fix)
- [x] **Tests added or updated** N/A (CI workflow fix)

---

## AI Summary

- **Scope:** .github/workflows
- **Type:** fix
- **Key files/areas:** .github/workflows/label-old-prs.yml
