### PR TITLE
fix(ci): use --json with gh pr list in label-old-prs workflow

### DIFF
--- a/.github/workflows/label-old-prs.yml
+++ b/.github/workflows/label-old-prs.yml
@@ -35,7 +35,7 @@ jobs:
         id: prs
         run: |
           echo "numbers<<EOF" >> $GITHUB_OUTPUT
-          gh pr list --state "${{ inputs.state }}" --limit "${{ inputs.limit }}" -q .number >> $GITHUB_OUTPUT
+          gh pr list --state "${{ inputs.state }}" --limit "${{ inputs.limit }}" --json number -q '.[].number' >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What is this feature?

Fix the "Label old PRs" workflow so it correctly fetches PR numbers: use `gh pr list --json number -q '.[].number'` so the GitHub CLI returns JSON and the jq query works.

## Why do we need this feature?

The workflow was failing with:
- `cannot use --jq without specifying --json` (gh requires `--json` when using `-q`)
- `Matching delimiter not found 'EOF'` (heredoc in GITHUB_OUTPUT was left open because the gh command failed)

## Who is this feature for?

Anyone who runs the "Label old PRs" workflow (Actions → Label old PRs → Run workflow) to backfill labels on existing PRs.

## Related issues

<!-- None -->

## Notes for reviewers

Single-line change in `.github/workflows/label-old-prs.yml`: add `--json number` and use jq query `'.[].number'` to output one PR number per line.

---

## Checklist

- [ ] **Breaking changes?** No
- [ ] **Documentation updated** N/A (workflow fix only)
- [ ] **Tests added or updated** N/A (CI workflow change)

---

## AI Summary

- **Scope:** .github/workflows (label-old-prs)
- **Type:** fix
- **Key files/areas:** .github/workflows/label-old-prs.yml
