### PR TITLE
docs(readme): remove Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 <p align="center">
   <a href="https://github.com/devopsfactory-io/neptune/releases"><img src="https://img.shields.io/github/v/release/devopsfactory-io/neptune?color=%239F50DA&display_name=tag&label=Version" alt="Latest Release" /></a>
   <a href="https://pkg.go.dev/github.com/devopsfactory-io/neptune"><img src="https://pkg.go.dev/badge/github.com/devopsfactory-io/neptune" alt="Go Docs" /></a>
-  <a href="https://goreportcard.com/report/github.com/devopsfactory-io/neptune"><img src="https://goreportcard.com/badge/github.com/devopsfactory-io/neptune" alt="Go Report Card" /></a>
   <a href="https://github.com/devopsfactory-io/neptune/actions?query=branch%3Amain"><img src="https://github.com/devopsfactory-io/neptune/actions/workflows/test.yml/badge.svg" alt="CI Status" /></a>
 </p>
 


### PR DESCRIPTION
## What is this feature?

Remove the Go Report Card badge from the README header.

## Why do we need this feature?

Simplify the README badges; the Go Report Card link is no longer needed in the project header.

## Who is this feature for?

Maintainers and readers of the repository who view the README.

## Related issues

<!-- e.g. Fixes #123 or Relates to #456 -->

## Notes for reviewers

Single-line removal in README.md (badge line only).

---

## Checklist

- [ ] **Breaking changes?** No
- [x] **Documentation updated** (README)
- [ ] **Tests added or updated** N/A (docs only)

---

## AI Summary

- **Scope:** docs (README)
- **Type:** docs
- **Key files/areas:** README.md
