### PR TITLE
docs: add Go Report Card badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <p align="center">
   <a href="https://github.com/devopsfactory-io/neptune/releases"><img src="https://img.shields.io/github/v/release/devopsfactory-io/neptune?color=%239F50DA&display_name=tag&label=Version" alt="Latest Release" /></a>
   <a href="https://pkg.go.dev/github.com/devopsfactory-io/neptune"><img src="https://pkg.go.dev/badge/github.com/devopsfactory-io/neptune" alt="Go Docs" /></a>
+  <a href="https://goreportcard.com/report/github.com/devopsfactory-io/neptune"><img src="https://goreportcard.com/badge/github.com/devopsfactory-io/neptune" alt="Go Report Card" /></a>
   <a href="https://github.com/devopsfactory-io/neptune/actions?query=branch%3Amain"><img src="https://github.com/devopsfactory-io/neptune/actions/workflows/test.yml/badge.svg" alt="CI Status" /></a>
 </p>
 


### PR DESCRIPTION
## What is this feature?

Adds a [Go Report Card](https://goreportcard.com/) badge to the README so visitors can see code quality (gofmt, go vet, etc.) at a glance.

## Why do we need this feature?

Improves discoverability of project quality metrics and aligns the README with common Go project conventions (alongside the existing version, pkg.go.dev, and CI badges).

## Who is this feature for?

Contributors and users evaluating the project; maintainers who want quality visibility on the repo front page.

## Related issues

<!-- e.g. Fixes #123 or Relates to #456 -->

## Notes for reviewers

Single-line addition: one badge link in the README badge row.

---

## Checklist

- [ ] **Breaking changes?** No
- [x] **Documentation updated** (README only)
- [ ] **Tests added or updated** N/A (docs only)

---

## AI Summary

- **Scope:** docs (README)
- **Type:** docs
- **Key files/areas:** README.md
